### PR TITLE
feat: introduce deterministic change intelligence core

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+# Terraform/OpenTofu's machine-readable plan JSON intentionally uses this token.
+ignore-words-list = applyable

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -41,6 +41,7 @@ jobs:
           - 1.10.0
           - 1.11.0
           - 1.12.0
+          - 1.15.8
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.10.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           go-version: "1.24"
       - name: Build for multiple platforms
         run: |
-          make build-all
+          make build-all VERSION="${GITHUB_REF_NAME}"
           chmod +x build/*
       - name: Create Release
         id: create_release

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -36,7 +36,7 @@ lint:
     - pre-commit-hooks@5.0.0
     - shellcheck@0.10.0
     - shfmt@3.6.0
-    - trivy@0.63.0
+    - trivy@0.70.0
     - yamlfmt@0.17.2
     - git-diff-check
     - markdownlint@0.45.0

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test: build
 	$(GOTEST) -v ./internal/...
 
 # Run integration tests
-test-integration: build test-show-terraform test-integration-plan-graph test-summarize-plan
+test-integration: build test-show-terraform test-integration-plan-graph test-summarize-plan test-analyze
 
 test-show-terraform:
 	$(MAKE) -C integration_tests/show_terraform all
@@ -60,6 +60,9 @@ test-integration-plan-graph:
 
 test-summarize-plan:
 	$(MAKE) -C integration_tests/summarize_plan all
+
+test-analyze:
+	$(MAKE) -C integration_tests/analyze all
 
 # Run tests with coverage
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,12 @@
 BINARY_NAME=terraform-ops
 BUILD_DIR=build
 MAIN_PATH=./cmd/terraform-ops
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS=-X github.com/yu/terraform-ops/internal/version.Version=$(VERSION)
 
 # Go variables
 GOCMD=go
-GOBUILD=$(GOCMD) build
+GOBUILD=$(GOCMD) build -ldflags "$(LDFLAGS)"
 GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get

--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -1,0 +1,53 @@
+# `terraform-ops analyze`
+
+`analyze` is the first v2 change-intelligence command. It consumes Terraform/OpenTofu plan JSON and produces deterministic, sanitized evidence for humans and CI.
+
+```bash
+terraform show -json tfplan > plan.json
+terraform-ops analyze plan.json
+terraform-ops analyze plan.json --format json
+terraform-ops analyze plan.json --format markdown
+terraform-ops analyze plan.json --fail-on high
+cat plan.json | terraform-ops analyze - --engine terraform
+```
+
+## Security model
+
+Raw plan values are source data, not the domain model. The command:
+
+1. enforces a bounded input size (64 MiB by default);
+2. parses the Terraform/OpenTofu 1.x JSON plan contract;
+3. applies `before_sensitive` / `after_sensitive` masks before normalization;
+4. removes variable values from the normalized model;
+5. exposes only sanitized evidence to analyzers and report formatters.
+
+`--redaction strict` removes all before/after resource values, not only values marked sensitive by the source plan.
+
+The stable report intentionally does not publish raw before/after values. It publishes change semantics such as action order, replacement paths, action reasons, unknown/sensitive paths, checks, drift, and dependency/blast-radius counts.
+
+## Initial rules
+
+| Rule | Default severity | Meaning |
+|---|---|---|
+| `TFOPS-PLAN-ERRORED` | high | Planning reported an error. |
+| `TFOPS-PLAN-INCOMPLETE` | medium | The plan may require another round to converge. |
+| `TFOPS-CHECK-FAILED` | high | A Terraform/OpenTofu check failed or errored. |
+| `TFOPS-LIFECYCLE-DELETE` | medium | A managed resource is deleted. |
+| `TFOPS-LIFECYCLE-REPLACE` | medium | A managed resource is replaced. |
+| `TFOPS-DRIFT-DETECTED` | medium | External drift is present in the plan. |
+| `TFOPS-SENSITIVE-MUTATION` | info | Sensitive paths participate in a change. |
+| `TFOPS-UNKNOWN-AFTER` | info | Values remain unknown until apply. |
+
+Every rule is deterministic and evidence-backed. Provider-specific risk classification is intentionally outside the initial core.
+
+## Engine selection
+
+`--engine auto` records the source as `unknown-compatible` because the compatible JSON plan format does not reliably identify Terraform vs OpenTofu. Use `--engine terraform` or `--engine opentofu` when the caller knows which engine generated the plan.
+
+## Exit behavior
+
+`--fail-on` renders the report first and then returns a command error if the highest finding meets or exceeds the configured threshold. This makes the same invocation useful for both PR summaries and CI gates.
+
+## Machine contract
+
+The JSON report is versioned independently of the Terraform/OpenTofu plan format. Its schema lives at `schemas/analysis-report-v1.schema.json`.

--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -27,16 +27,16 @@ The stable report intentionally does not publish raw before/after values. It pub
 
 ## Initial rules
 
-| Rule | Default severity | Meaning |
-|---|---|---|
-| `TFOPS-PLAN-ERRORED` | high | Planning reported an error. |
-| `TFOPS-PLAN-INCOMPLETE` | medium | The plan may require another round to converge. |
-| `TFOPS-CHECK-FAILED` | high | A Terraform/OpenTofu check failed or errored. |
-| `TFOPS-LIFECYCLE-DELETE` | medium | A managed resource is deleted. |
-| `TFOPS-LIFECYCLE-REPLACE` | medium | A managed resource is replaced. |
-| `TFOPS-DRIFT-DETECTED` | medium | External drift is present in the plan. |
-| `TFOPS-SENSITIVE-MUTATION` | info | Sensitive paths participate in a change. |
-| `TFOPS-UNKNOWN-AFTER` | info | Values remain unknown until apply. |
+| Rule                       | Default severity | Meaning                                         |
+| -------------------------- | ---------------- | ----------------------------------------------- |
+| `TFOPS-PLAN-ERRORED`       | high             | Planning reported an error.                     |
+| `TFOPS-PLAN-INCOMPLETE`    | medium           | The plan may require another round to converge. |
+| `TFOPS-CHECK-FAILED`       | high             | A Terraform/OpenTofu check failed or errored.   |
+| `TFOPS-LIFECYCLE-DELETE`   | medium           | A managed resource is deleted.                  |
+| `TFOPS-LIFECYCLE-REPLACE`  | medium           | A managed resource is replaced.                 |
+| `TFOPS-DRIFT-DETECTED`     | medium           | External drift is present in the plan.          |
+| `TFOPS-SENSITIVE-MUTATION` | info             | Sensitive paths participate in a change.        |
+| `TFOPS-UNKNOWN-AFTER`      | info             | Values remain unknown until apply.              |
 
 Every rule is deterministic and evidence-backed. Provider-specific risk classification is intentionally outside the initial core.
 

--- a/integration_tests/analyze/Makefile
+++ b/integration_tests/analyze/Makefile
@@ -1,0 +1,25 @@
+# Integration test Makefile for analyze
+
+.PHONY: all build test generate-plans clean-plans
+
+# Build the binary in the expected location.
+build:
+	cd ../.. && go build -o integration_tests/build/terraform-ops ./cmd/terraform-ops
+
+# Generate plan JSON with the Terraform version selected by the CI matrix.
+generate-plans:
+	cd workspaces/simple && terraform init -input=false
+	cd workspaces/simple && terraform plan -out=plan.tfplan -input=false
+	cd workspaces/simple && terraform show -json plan.tfplan > plan.json
+
+clean-plans:
+	rm -f workspaces/simple/plan.tfplan
+	rm -f workspaces/simple/plan.json
+	rm -rf workspaces/simple/.terraform
+	rm -f workspaces/simple/.terraform.lock.hcl
+
+# The generated plan is deliberately retained while the Go test executes.
+test:
+	go test -v ./...
+
+all: build generate-plans test

--- a/integration_tests/analyze/integration_test.go
+++ b/integration_tests/analyze/integration_test.go
@@ -55,10 +55,16 @@ func TestAnalyzeCommandRedactsGeneratedPlan(t *testing.T) {
 
 	var report struct {
 		SchemaVersion string `json:"schema_version"`
-		Source        struct {
+		Tool          struct {
+			Version string `json:"version"`
+		} `json:"tool"`
+		Source struct {
 			Engine            string `json:"engine"`
 			PlanFormatVersion string `json:"plan_format_version"`
 		} `json:"source"`
+		Plan struct {
+			Complete bool `json:"complete"`
+		} `json:"plan"`
 		Changes []struct {
 			Address        string   `json:"address"`
 			SensitivePaths []string `json:"sensitive_paths"`
@@ -78,8 +84,14 @@ func TestAnalyzeCommandRedactsGeneratedPlan(t *testing.T) {
 	if report.SchemaVersion != "1.0" {
 		t.Fatalf("unexpected report schema version %q", report.SchemaVersion)
 	}
+	if report.Tool.Version == "" || report.Tool.Version == "dev" {
+		t.Fatalf("expected build-stamped tool version, got %q", report.Tool.Version)
+	}
 	if report.Source.Engine != "terraform" || report.Source.PlanFormatVersion == "" {
 		t.Fatalf("unexpected source metadata: %#v", report.Source)
+	}
+	if !report.Plan.Complete {
+		t.Fatal("generated converged plan was reported incomplete")
 	}
 	if report.Redaction.VariableValuesRemoved < 1 {
 		t.Fatal("expected source variable values to be removed before analysis")
@@ -88,7 +100,7 @@ func TestAnalyzeCommandRedactsGeneratedPlan(t *testing.T) {
 		t.Fatal("expected at least one Terraform-sensitive path in the generated plan")
 	}
 
-	var source, consumer *struct {
+	var source, child, consumer *struct {
 		Address        string   `json:"address"`
 		SensitivePaths []string `json:"sensitive_paths"`
 		BlastRadius    struct {
@@ -100,17 +112,22 @@ func TestAnalyzeCommandRedactsGeneratedPlan(t *testing.T) {
 		switch report.Changes[i].Address {
 		case "terraform_data.source":
 			source = &report.Changes[i]
+		case "module.child.terraform_data.child":
+			child = &report.Changes[i]
 		case "terraform_data.consumer":
 			consumer = &report.Changes[i]
 		}
 	}
-	if source == nil || consumer == nil {
-		t.Fatalf("expected source and consumer changes, got %#v", report.Changes)
+	if source == nil || child == nil || consumer == nil {
+		t.Fatalf("expected source, child, and consumer changes, got %#v", report.Changes)
 	}
 	if len(source.SensitivePaths) == 0 {
 		t.Fatal("source resource lost sensitive-path evidence")
 	}
-	if source.BlastRadius.DirectDependents < 1 || source.BlastRadius.TransitiveDependents < 1 {
-		t.Fatalf("expected source blast radius to include consumer, got %#v", source.BlastRadius)
+	if source.BlastRadius.DirectDependents < 1 || source.BlastRadius.TransitiveDependents < 2 {
+		t.Fatalf("expected module input to propagate source blast radius, got %#v", source.BlastRadius)
+	}
+	if child.BlastRadius.DirectDependents < 1 || child.BlastRadius.TransitiveDependents < 1 {
+		t.Fatalf("expected module output to propagate child blast radius, got %#v", child.BlastRadius)
 	}
 }

--- a/integration_tests/analyze/integration_test.go
+++ b/integration_tests/analyze/integration_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const integrationCanary = "TFOPS_INTEGRATION_SECRET_CANARY_7f3d91"
+
+func TestAnalyzeCommandRedactsGeneratedPlan(t *testing.T) {
+	planPath := "workspaces/simple/plan.json"
+	planJSON, err := os.ReadFile(planPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(planJSON, []byte(integrationCanary)) {
+		t.Fatal("generated plan does not contain the canary; the fixture cannot prove redaction")
+	}
+
+	cmd := exec.Command(
+		"../../build/terraform-ops",
+		"analyze",
+		"--format", "json",
+		"--engine", "terraform",
+		planPath,
+	)
+	cmd.Dir = "."
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("analyze failed: %v\nstderr: %s", err, stderr.String())
+	}
+	if strings.Contains(stdout.String(), integrationCanary) {
+		t.Fatal("analyze output leaked the sensitive integration-test canary")
+	}
+
+	var report struct {
+		SchemaVersion string `json:"schema_version"`
+		Source        struct {
+			Engine            string `json:"engine"`
+			PlanFormatVersion string `json:"plan_format_version"`
+		} `json:"source"`
+		Changes []struct {
+			Address        string   `json:"address"`
+			SensitivePaths []string `json:"sensitive_paths"`
+			BlastRadius    struct {
+				DirectDependents     int `json:"direct_dependents"`
+				TransitiveDependents int `json:"transitive_dependents"`
+			} `json:"blast_radius"`
+		} `json:"changes"`
+		Redaction struct {
+			SensitivePaths        int `json:"terraform_sensitive_paths"`
+			VariableValuesRemoved int `json:"variable_values_removed"`
+		} `json:"redaction"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode analysis report: %v\noutput: %s", err, stdout.String())
+	}
+	if report.SchemaVersion != "1.0" {
+		t.Fatalf("unexpected report schema version %q", report.SchemaVersion)
+	}
+	if report.Source.Engine != "terraform" || report.Source.PlanFormatVersion == "" {
+		t.Fatalf("unexpected source metadata: %#v", report.Source)
+	}
+	if report.Redaction.VariableValuesRemoved < 1 {
+		t.Fatal("expected source variable values to be removed before analysis")
+	}
+	if report.Redaction.SensitivePaths < 1 {
+		t.Fatal("expected at least one Terraform-sensitive path in the generated plan")
+	}
+
+	var source, consumer *struct {
+		Address        string   `json:"address"`
+		SensitivePaths []string `json:"sensitive_paths"`
+		BlastRadius    struct {
+			DirectDependents     int `json:"direct_dependents"`
+			TransitiveDependents int `json:"transitive_dependents"`
+		} `json:"blast_radius"`
+	}
+	for i := range report.Changes {
+		switch report.Changes[i].Address {
+		case "terraform_data.source":
+			source = &report.Changes[i]
+		case "terraform_data.consumer":
+			consumer = &report.Changes[i]
+		}
+	}
+	if source == nil || consumer == nil {
+		t.Fatalf("expected source and consumer changes, got %#v", report.Changes)
+	}
+	if len(source.SensitivePaths) == 0 {
+		t.Fatal("source resource lost sensitive-path evidence")
+	}
+	if source.BlastRadius.DirectDependents < 1 || source.BlastRadius.TransitiveDependents < 1 {
+		t.Fatalf("expected source blast radius to include consumer, got %#v", source.BlastRadius)
+	}
+}

--- a/integration_tests/analyze/workspaces/simple/child/main.tf
+++ b/integration_tests/analyze/workspaces/simple/child/main.tf
@@ -1,0 +1,13 @@
+variable "source_id" {
+  type = string
+}
+
+resource "terraform_data" "child" {
+  input = {
+    source_id = var.source_id
+  }
+}
+
+output "result" {
+  value = terraform_data.child.id
+}

--- a/integration_tests/analyze/workspaces/simple/main.tf
+++ b/integration_tests/analyze/workspaces/simple/main.tf
@@ -16,9 +16,15 @@ resource "terraform_data" "source" {
   }
 }
 
+module "child" {
+  source = "./child"
+
+  source_id = terraform_data.source.id
+}
+
 resource "terraform_data" "consumer" {
   input = {
-    source_id = terraform_data.source.id
+    child_id = module.child.result
   }
 }
 

--- a/integration_tests/analyze/workspaces/simple/main.tf
+++ b/integration_tests/analyze/workspaces/simple/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.7.0"
+}
+
+variable "secret" {
+  description = "Sensitive integration-test canary"
+  type        = string
+  sensitive   = true
+  default     = "TFOPS_INTEGRATION_SECRET_CANARY_7f3d91"
+}
+
+resource "terraform_data" "source" {
+  input = {
+    secret = var.secret
+    name   = "source"
+  }
+}
+
+resource "terraform_data" "consumer" {
+  input = {
+    source_id = terraform_data.source.id
+  }
+}
+
+output "source_secret" {
+  value     = terraform_data.source.output.secret
+  sensitive = true
+}

--- a/internal/analysis/analyzer.go
+++ b/internal/analysis/analyzer.go
@@ -1,0 +1,67 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/yu/terraform-ops/internal/ir"
+	"github.com/yu/terraform-ops/internal/report"
+)
+
+type Analyzer interface {
+	ID() string
+	Analyze(context.Context, *ir.ChangeSet) ([]report.Finding, error)
+}
+
+type Registry struct {
+	analyzers []Analyzer
+}
+
+func NewRegistry(analyzers ...Analyzer) *Registry {
+	return &Registry{analyzers: append([]Analyzer(nil), analyzers...)}
+}
+
+func DefaultRegistry() *Registry {
+	return NewRegistry(
+		planAnalyzer{},
+		checkAnalyzer{},
+		lifecycleAnalyzer{},
+		driftAnalyzer{},
+		sensitivityAnalyzer{},
+		unknownAnalyzer{},
+	)
+}
+
+func (r *Registry) Analyze(ctx context.Context, changeSet *ir.ChangeSet) ([]report.Finding, error) {
+	if changeSet == nil {
+		return nil, fmt.Errorf("change set is nil")
+	}
+	var findings []report.Finding
+	for _, analyzer := range r.analyzers {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		items, err := analyzer.Analyze(ctx, changeSet)
+		if err != nil {
+			return nil, fmt.Errorf("analyzer %s: %w", analyzer.ID(), err)
+		}
+		findings = append(findings, items...)
+	}
+	wrapper := report.AnalysisReport{Findings: findings}
+	report.Sort(&wrapper)
+	return wrapper.Findings, nil
+}

--- a/internal/analysis/generic.go
+++ b/internal/analysis/generic.go
@@ -1,0 +1,236 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/yu/terraform-ops/internal/ir"
+	"github.com/yu/terraform-ops/internal/report"
+)
+
+type planAnalyzer struct{}
+
+func (planAnalyzer) ID() string { return "plan" }
+func (planAnalyzer) Analyze(_ context.Context, cs *ir.ChangeSet) ([]report.Finding, error) {
+	var findings []report.Finding
+	if cs.Plan.Errored {
+		findings = append(findings, report.Finding{
+			RuleID:     "TFOPS-PLAN-ERRORED",
+			Title:      "Terraform/OpenTofu planning errored",
+			Category:   report.CategoryPlan,
+			Severity:   report.SeverityHigh,
+			Confidence: report.ConfidenceExact,
+			Message:    "Planning reported an error; the available change set may be partial and cannot be safely treated as a complete plan.",
+		})
+	}
+	if !cs.Plan.Complete {
+		findings = append(findings, report.Finding{
+			RuleID:     "TFOPS-PLAN-INCOMPLETE",
+			Title:      "Plan is incomplete",
+			Category:   report.CategoryUncertainty,
+			Severity:   report.SeverityMedium,
+			Confidence: report.ConfidenceExact,
+			Message:    "The plan is not complete; an additional plan/apply round may be required to converge.",
+		})
+	}
+	return findings, nil
+}
+
+type checkAnalyzer struct{}
+
+func (checkAnalyzer) ID() string { return "checks" }
+func (checkAnalyzer) Analyze(_ context.Context, cs *ir.ChangeSet) ([]report.Finding, error) {
+	var findings []report.Finding
+	for _, check := range cs.Checks {
+		if check.Status != ir.CheckFail && check.Status != ir.CheckError {
+			continue
+		}
+		findings = append(findings, report.Finding{
+			RuleID:     "TFOPS-CHECK-FAILED",
+			Title:      "Terraform/OpenTofu check failed",
+			Category:   report.CategoryValidation,
+			Severity:   report.SeverityHigh,
+			Confidence: report.ConfidenceExact,
+			Resource:   &report.ResourceRef{Address: check.Address},
+			Evidence: []report.Evidence{{
+				Kind:        "check_status",
+				Description: string(check.Status),
+				Source:      "plan.checks",
+			}},
+			Message: fmt.Sprintf("Check %s has status %s.", check.Address, check.Status),
+		})
+	}
+	return findings, nil
+}
+
+type lifecycleAnalyzer struct{}
+
+func (lifecycleAnalyzer) ID() string { return "lifecycle" }
+func (lifecycleAnalyzer) Analyze(_ context.Context, cs *ir.ChangeSet) ([]report.Finding, error) {
+	var findings []report.Finding
+	for _, resource := range cs.Resources {
+		if resource.Mode != ir.ResourceModeManaged {
+			continue
+		}
+		switch {
+		case resource.Action.Semantic == ir.ActionDelete:
+			findings = append(findings, report.Finding{
+				RuleID:     "TFOPS-LIFECYCLE-DELETE",
+				Title:      "Managed resource deletion",
+				Category:   report.CategoryLifecycle,
+				Severity:   report.SeverityMedium,
+				Confidence: report.ConfidenceExact,
+				Resource:   resourceRef(resource),
+				Evidence: []report.Evidence{{
+					Kind:        "action",
+					Description: "delete",
+					Source:      "resource_changes.change.actions",
+				}},
+				Message: "A managed resource is planned for deletion.",
+			})
+		case resource.Action.IsReplace():
+			evidence := []report.Evidence{{
+				Kind:        "replacement_order",
+				Description: string(resource.Action.Semantic),
+				Source:      "resource_changes.change.actions",
+			}}
+			for _, path := range resource.ReplacePaths {
+				evidence = append(evidence, report.Evidence{
+					Kind:   "replace_path",
+					Path:   path.String(),
+					Source: "resource_changes.change.replace_paths",
+				})
+			}
+			if resource.ActionReason != "" {
+				evidence = append(evidence, report.Evidence{
+					Kind:        "action_reason",
+					Description: resource.ActionReason,
+					Source:      "resource_changes.action_reason",
+				})
+			}
+			findings = append(findings, report.Finding{
+				RuleID:     "TFOPS-LIFECYCLE-REPLACE",
+				Title:      "Managed resource replacement",
+				Category:   report.CategoryLifecycle,
+				Severity:   report.SeverityMedium,
+				Confidence: report.ConfidenceExact,
+				Resource:   resourceRef(resource),
+				Evidence:   evidence,
+				Message:    "A managed resource is planned for replacement.",
+			})
+		}
+	}
+	return findings, nil
+}
+
+type driftAnalyzer struct{}
+
+func (driftAnalyzer) ID() string { return "drift" }
+func (driftAnalyzer) Analyze(_ context.Context, cs *ir.ChangeSet) ([]report.Finding, error) {
+	var findings []report.Finding
+	for _, drift := range cs.Drift {
+		evidence := []report.Evidence{{
+			Kind:        "resource_drift",
+			Description: string(drift.Resource.Action.Semantic),
+			Source:      "resource_drift",
+		}}
+		for _, relevant := range drift.Relevant {
+			evidence = append(evidence, report.Evidence{
+				Kind:   "relevant_attribute",
+				Path:   relevant.Path.String(),
+				Source: "relevant_attributes",
+			})
+		}
+		findings = append(findings, report.Finding{
+			RuleID:     "TFOPS-DRIFT-DETECTED",
+			Title:      "External drift detected",
+			Category:   report.CategoryDrift,
+			Severity:   report.SeverityMedium,
+			Confidence: report.ConfidenceExact,
+			Resource:   resourceRef(drift.Resource),
+			Evidence:   evidence,
+			Message:    "The plan reports external drift for this resource; relevant attributes are correlation evidence, not proof of causation.",
+		})
+	}
+	return findings, nil
+}
+
+type sensitivityAnalyzer struct{}
+
+func (sensitivityAnalyzer) ID() string { return "sensitivity" }
+func (sensitivityAnalyzer) Analyze(_ context.Context, cs *ir.ChangeSet) ([]report.Finding, error) {
+	var findings []report.Finding
+	for _, resource := range cs.Resources {
+		if len(resource.SensitivePaths) == 0 || resource.Action.Semantic == ir.ActionNoOp {
+			continue
+		}
+		evidence := make([]report.Evidence, 0, len(resource.SensitivePaths))
+		for _, path := range resource.SensitivePaths {
+			evidence = append(evidence, report.Evidence{
+				Kind:   "sensitive_path",
+				Path:   path.String(),
+				Source: "before_sensitive/after_sensitive",
+			})
+		}
+		findings = append(findings, report.Finding{
+			RuleID:     "TFOPS-SENSITIVE-MUTATION",
+			Title:      "Sensitive data participates in a resource change",
+			Category:   report.CategorySensitivity,
+			Severity:   report.SeverityInfo,
+			Confidence: report.ConfidenceExact,
+			Resource:   resourceRef(resource),
+			Evidence:   evidence,
+			Message:    "One or more Terraform/OpenTofu-sensitive paths participate in this resource change; values have been redacted before analysis output.",
+		})
+	}
+	return findings, nil
+}
+
+type unknownAnalyzer struct{}
+
+func (unknownAnalyzer) ID() string { return "unknown" }
+func (unknownAnalyzer) Analyze(_ context.Context, cs *ir.ChangeSet) ([]report.Finding, error) {
+	var findings []report.Finding
+	for _, resource := range cs.Resources {
+		if len(resource.UnknownPaths) == 0 || resource.Action.Semantic == ir.ActionNoOp {
+			continue
+		}
+		evidence := make([]report.Evidence, 0, len(resource.UnknownPaths))
+		for _, path := range resource.UnknownPaths {
+			evidence = append(evidence, report.Evidence{
+				Kind:   "unknown_after_path",
+				Path:   path.String(),
+				Source: "after_unknown",
+			})
+		}
+		findings = append(findings, report.Finding{
+			RuleID:     "TFOPS-UNKNOWN-AFTER",
+			Title:      "Post-apply values remain unknown",
+			Category:   report.CategoryUncertainty,
+			Severity:   report.SeverityInfo,
+			Confidence: report.ConfidenceExact,
+			Resource:   resourceRef(resource),
+			Evidence:   evidence,
+			Message:    "One or more changed attributes are unknown until apply.",
+		})
+	}
+	return findings, nil
+}
+
+func resourceRef(resource ir.ResourceChange) *report.ResourceRef {
+	return &report.ResourceRef{Address: string(resource.Address), Type: resource.Type}
+}

--- a/internal/analysis/generic_test.go
+++ b/internal/analysis/generic_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/yu/terraform-ops/internal/ir"
+	"github.com/yu/terraform-ops/internal/report"
+)
+
+func TestDefaultRegistryProducesEvidenceBackedFindings(t *testing.T) {
+	path := ir.AttributePath{ir.Attribute("disk_type")}
+	cs := &ir.ChangeSet{
+		Plan: ir.PlanMetadata{Applyable: true, Complete: true},
+		Resources: []ir.ResourceChange{{
+			Address:        "test_resource.db",
+			Mode:           ir.ResourceModeManaged,
+			Type:           "test_resource",
+			Action:         ir.NormalizeAction([]string{"delete", "create"}),
+			ActionReason:   "replace_because_cannot_update",
+			ReplacePaths:   []ir.AttributePath{path},
+			SensitivePaths: []ir.AttributePath{{ir.Attribute("password")}},
+			UnknownPaths:   []ir.AttributePath{{ir.Attribute("endpoint")}},
+		}},
+	}
+	findings, err := DefaultRegistry().Analyze(context.Background(), cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 3 {
+		t.Fatalf("got %d findings: %#v", len(findings), findings)
+	}
+	if findings[0].RuleID != "TFOPS-LIFECYCLE-REPLACE" || findings[0].Severity != report.SeverityMedium {
+		t.Fatalf("unexpected first finding: %#v", findings[0])
+	}
+	foundReplacePath := false
+	for _, evidence := range findings[0].Evidence {
+		if evidence.Kind == "replace_path" && evidence.Path == "disk_type" {
+			foundReplacePath = true
+		}
+	}
+	if !foundReplacePath {
+		t.Fatal("replacement finding omitted replace_path evidence")
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -39,6 +39,7 @@ func init() {
 	rootCmd.AddCommand(commands.DefaultShowTerraformCommand().Command())
 	rootCmd.AddCommand(commands.DefaultPlanGraphCommand().Command())
 	rootCmd.AddCommand(commands.DefaultSummarizePlanCommand().Command())
+	rootCmd.AddCommand(commands.DefaultAnalyzeCommand().Command())
 }
 
 // Run executes the root command

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -21,14 +21,16 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/yu/terraform-ops/internal/commands"
+	"github.com/yu/terraform-ops/internal/version"
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "terraform-ops",
-	Short: "Terraform operations CLI tool",
-	Long:  `A CLI tool for managing Terraform operations and workflows`,
+	Use:     "terraform-ops",
+	Short:   "Terraform operations CLI tool",
+	Long:    `A CLI tool for managing Terraform operations and workflows`,
+	Version: version.Version,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Terraform Ops CLI v1.0.0")
+		fmt.Printf("Terraform Ops CLI %s\n", version.Version)
 		fmt.Println("Use --help for more information")
 	},
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -35,6 +35,8 @@ func TestRootCmd(t *testing.T) {
 	assert.True(t, rootCmd.HasSubCommands())
 	assert.NotNil(t, findCommand(rootCmd, "show-terraform"))
 	assert.NotNil(t, findCommand(rootCmd, "plan-graph"))
+	assert.NotNil(t, findCommand(rootCmd, "summarize-plan"))
+	assert.NotNil(t, findCommand(rootCmd, "analyze"))
 }
 
 // TestShowTerraformCmd tests the 'show-terraform' command execution

--- a/internal/commands/analyze.go
+++ b/internal/commands/analyze.go
@@ -1,0 +1,199 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/yu/terraform-ops/internal/analysis"
+	"github.com/yu/terraform-ops/internal/ir"
+	"github.com/yu/terraform-ops/internal/report"
+	terraformsource "github.com/yu/terraform-ops/internal/source/terraform"
+)
+
+type AnalyzeCommand struct {
+	registry *analysis.Registry
+	stdin    io.Reader
+	stdout   io.Writer
+}
+
+type analyzeOptions struct {
+	format      string
+	engine      string
+	redaction   string
+	failOn      string
+	output      string
+	maxPlanSize int64
+}
+
+func NewAnalyzeCommand(registry *analysis.Registry, stdin io.Reader, stdout io.Writer) *AnalyzeCommand {
+	return &AnalyzeCommand{registry: registry, stdin: stdin, stdout: stdout}
+}
+
+func DefaultAnalyzeCommand() *AnalyzeCommand {
+	return NewAnalyzeCommand(analysis.DefaultRegistry(), os.Stdin, os.Stdout)
+}
+
+func (c *AnalyzeCommand) Command() *cobra.Command {
+	opts := analyzeOptions{}
+	cmd := &cobra.Command{
+		Use:   "analyze <PLAN_JSON>",
+		Short: "Analyze Terraform/OpenTofu changes, causes, uncertainty, and blast radius",
+		Long: `Analyze a Terraform/OpenTofu JSON plan without executing Terraform/OpenTofu.
+
+Raw plan values are sanitized before they enter the normalized analysis model. Use "-"
+to read a plan JSON document from stdin.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.run(cmd.Context(), args[0], opts)
+		},
+	}
+	cmd.Flags().StringVarP(&opts.format, "format", "f", string(report.FormatText), "Output format (text, json, markdown)")
+	cmd.Flags().StringVar(&opts.engine, "engine", "auto", "Source engine (auto, terraform, opentofu)")
+	cmd.Flags().StringVar(&opts.redaction, "redaction", string(ir.RedactionStandard), "Redaction mode (standard, strict)")
+	cmd.Flags().StringVar(&opts.failOn, "fail-on", "none", "Fail when a finding meets the severity threshold (none, info, low, medium, high, critical)")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", "", "Write the rendered report to a file instead of stdout")
+	cmd.Flags().Int64Var(&opts.maxPlanSize, "max-plan-bytes", terraformsource.DefaultMaxPlanBytes, "Maximum accepted plan JSON size in bytes")
+	return cmd
+}
+
+func (c *AnalyzeCommand) run(ctx context.Context, planPath string, opts analyzeOptions) error {
+	engine, err := parseEngine(opts.engine)
+	if err != nil {
+		return err
+	}
+	redaction, err := parseRedaction(opts.redaction)
+	if err != nil {
+		return err
+	}
+	format, err := parseAnalysisFormat(opts.format)
+	if err != nil {
+		return err
+	}
+	threshold, err := parseFailOn(opts.failOn)
+	if err != nil {
+		return err
+	}
+
+	var plan *terraformsource.Plan
+	if planPath == "-" {
+		plan, err = terraformsource.ParseReader(c.stdin, opts.maxPlanSize)
+	} else {
+		plan, err = terraformsource.ParseFile(planPath, opts.maxPlanSize)
+	}
+	if err != nil {
+		return err
+	}
+
+	changeSet, err := terraformsource.Normalize(plan, engine, redaction)
+	if err != nil {
+		return err
+	}
+	findings, err := c.registry.Analyze(ctx, changeSet)
+	if err != nil {
+		return err
+	}
+	analysisReport := report.Build(changeSet, findings, "dev")
+	rendered, err := report.Render(analysisReport, format)
+	if err != nil {
+		return err
+	}
+
+	if opts.output != "" {
+		if err := os.WriteFile(opts.output, rendered, 0o600); err != nil {
+			return fmt.Errorf("write analysis report: %w", err)
+		}
+	} else {
+		if _, err := c.stdout.Write(rendered); err != nil {
+			return fmt.Errorf("write analysis report: %w", err)
+		}
+	}
+
+	if threshold != "" && report.MeetsThreshold(report.HighestSeverity(findings), threshold) {
+		return &FindingThresholdError{Threshold: threshold, Highest: report.HighestSeverity(findings)}
+	}
+	return nil
+}
+
+type FindingThresholdError struct {
+	Threshold report.Severity
+	Highest   report.Severity
+}
+
+func (e *FindingThresholdError) Error() string {
+	return fmt.Sprintf("analysis finding threshold %s exceeded (highest severity: %s)", e.Threshold, e.Highest)
+}
+
+func parseEngine(value string) (ir.Engine, error) {
+	switch strings.ToLower(value) {
+	case "auto":
+		return ir.EngineUnknown, nil
+	case "terraform":
+		return ir.EngineTerraform, nil
+	case "opentofu", "tofu":
+		return ir.EngineOpenTofu, nil
+	default:
+		return "", fmt.Errorf("unsupported engine %q: use auto, terraform, or opentofu", value)
+	}
+}
+
+func parseRedaction(value string) (ir.RedactionMode, error) {
+	switch ir.RedactionMode(strings.ToLower(value)) {
+	case ir.RedactionStandard:
+		return ir.RedactionStandard, nil
+	case ir.RedactionStrict:
+		return ir.RedactionStrict, nil
+	default:
+		return "", fmt.Errorf("unsupported redaction mode %q: use standard or strict", value)
+	}
+}
+
+func parseAnalysisFormat(value string) (report.Format, error) {
+	switch report.Format(strings.ToLower(value)) {
+	case report.FormatText:
+		return report.FormatText, nil
+	case report.FormatJSON:
+		return report.FormatJSON, nil
+	case report.FormatMarkdown:
+		return report.FormatMarkdown, nil
+	default:
+		return "", fmt.Errorf("unsupported analysis format %q: use text, json, or markdown", value)
+	}
+}
+
+func parseFailOn(value string) (report.Severity, error) {
+	switch report.Severity(strings.ToLower(value)) {
+	case "none":
+		return "", nil
+	case report.SeverityInfo:
+		return report.SeverityInfo, nil
+	case report.SeverityLow:
+		return report.SeverityLow, nil
+	case report.SeverityMedium:
+		return report.SeverityMedium, nil
+	case report.SeverityHigh:
+		return report.SeverityHigh, nil
+	case report.SeverityCritical:
+		return report.SeverityCritical, nil
+	default:
+		return "", fmt.Errorf("unsupported fail-on threshold %q", value)
+	}
+}

--- a/internal/commands/analyze.go
+++ b/internal/commands/analyze.go
@@ -27,6 +27,7 @@ import (
 	"github.com/yu/terraform-ops/internal/ir"
 	"github.com/yu/terraform-ops/internal/report"
 	terraformsource "github.com/yu/terraform-ops/internal/source/terraform"
+	"github.com/yu/terraform-ops/internal/version"
 )
 
 type AnalyzeCommand struct {
@@ -111,7 +112,7 @@ func (c *AnalyzeCommand) run(ctx context.Context, planPath string, opts analyzeO
 	if err != nil {
 		return err
 	}
-	analysisReport := report.Build(changeSet, findings, "dev")
+	analysisReport := report.Build(changeSet, findings, version.Version)
 	rendered, err := report.Render(analysisReport, format)
 	if err != nil {
 		return err

--- a/internal/commands/analyze_test.go
+++ b/internal/commands/analyze_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/yu/terraform-ops/internal/analysis"
+)
+
+func TestAnalyzeCommandJSONDoesNotLeakSensitiveCanary(t *testing.T) {
+	const canary = "TFOPS_COMMAND_CANARY_a91d3f"
+	input := `{
+  "format_version":"1.0",
+  "applyable":true,
+  "complete":true,
+  "errored":false,
+  "variables":{"secret":{"value":"` + canary + `"}},
+  "resource_changes":[{
+    "address":"test_resource.example",
+    "mode":"managed",
+    "type":"test_resource",
+    "name":"example",
+    "change":{
+      "actions":["update"],
+      "before":{"secret":"` + canary + `"},
+      "after":{"secret":"` + canary + `"},
+      "before_sensitive":{"secret":true},
+      "after_sensitive":{"secret":true}
+    }
+  }],
+  "output_changes":{},
+  "configuration":{"root_module":{"resources":[],"module_calls":{},"outputs":{}}}
+}`
+	var stdout bytes.Buffer
+	cmd := NewAnalyzeCommand(analysis.DefaultRegistry(), strings.NewReader(input), &stdout)
+	err := cmd.run(context.Background(), "-", analyzeOptions{
+		format:      "json",
+		engine:      "terraform",
+		redaction:   "standard",
+		failOn:      "none",
+		maxPlanSize: 1 << 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stdout.String(), canary) {
+		t.Fatal("analysis output leaked canary")
+	}
+	if !strings.Contains(stdout.String(), `"rule_id": "TFOPS-SENSITIVE-MUTATION"`) {
+		t.Fatal("expected sensitive mutation finding")
+	}
+}
+
+func TestAnalyzeCommandFailOnReturnsErrorAfterRendering(t *testing.T) {
+	input := `{
+  "format_version":"1.0",
+  "applyable":true,
+  "complete":true,
+  "errored":false,
+  "resource_changes":[{
+    "address":"test_resource.example",
+    "mode":"managed",
+    "type":"test_resource",
+    "name":"example",
+    "change":{"actions":["delete"]}
+  }],
+  "output_changes":{},
+  "configuration":{"root_module":{"resources":[],"module_calls":{},"outputs":{}}}
+}`
+	var stdout bytes.Buffer
+	cmd := NewAnalyzeCommand(analysis.DefaultRegistry(), strings.NewReader(input), &stdout)
+	err := cmd.run(context.Background(), "-", analyzeOptions{
+		format:      "text",
+		engine:      "terraform",
+		redaction:   "standard",
+		failOn:      "medium",
+		maxPlanSize: 1 << 20,
+	})
+	if err == nil {
+		t.Fatal("expected threshold error")
+	}
+	if stdout.Len() == 0 {
+		t.Fatal("expected report to be rendered before threshold error")
+	}
+}

--- a/internal/commands/analyze_test.go
+++ b/internal/commands/analyze_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/yu/terraform-ops/internal/analysis"
+	"github.com/yu/terraform-ops/internal/version"
 )
 
 func TestAnalyzeCommandJSONDoesNotLeakSensitiveCanary(t *testing.T) {
@@ -64,6 +65,38 @@ func TestAnalyzeCommandJSONDoesNotLeakSensitiveCanary(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), `"rule_id": "TFOPS-SENSITIVE-MUTATION"`) {
 		t.Fatal("expected sensitive mutation finding")
+	}
+}
+
+func TestAnalyzeCommandReportsBuildVersion(t *testing.T) {
+	originalVersion := version.Version
+	version.Version = "v9.9.9-test"
+	defer func() { version.Version = originalVersion }()
+
+	input := `{
+  "format_version":"1.0",
+  "terraform_version":"1.15.8",
+  "applyable":true,
+  "complete":true,
+  "errored":false,
+  "resource_changes":[],
+  "output_changes":{},
+  "configuration":{"root_module":{"resources":[],"module_calls":{},"outputs":{}}}
+}`
+	var stdout bytes.Buffer
+	cmd := NewAnalyzeCommand(analysis.DefaultRegistry(), strings.NewReader(input), &stdout)
+	err := cmd.run(context.Background(), "-", analyzeOptions{
+		format:      "json",
+		engine:      "terraform",
+		redaction:   "standard",
+		failOn:      "none",
+		maxPlanSize: 1 << 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), `"version": "v9.9.9-test"`) {
+		t.Fatalf("analysis report did not contain build version: %s", stdout.String())
 	}
 }
 

--- a/internal/core/terraform_plan_json.go
+++ b/internal/core/terraform_plan_json.go
@@ -1,0 +1,39 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import "encoding/json"
+
+// UnmarshalJSON keeps the legacy TerraformPlan domain compatible with current
+// Terraform/OpenTofu plan JSON. The machine-readable plan contract calls this
+// field "applyable"; older terraform-ops tests and fixtures used "applicable".
+// Accept both during the legacy-command migration and prefer the source-contract
+// spelling when both are present.
+func (p *TerraformPlan) UnmarshalJSON(data []byte) error {
+	type alias TerraformPlan
+	decoded := struct {
+		*alias
+		Applyable *bool `json:"applyable"`
+	}{
+		alias: (*alias)(p),
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	if decoded.Applyable != nil {
+		p.Applicable = *decoded.Applyable
+	}
+	return nil
+}

--- a/internal/core/terraform_plan_json_test.go
+++ b/internal/core/terraform_plan_json_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTerraformPlanUnmarshalCurrentApplyableField(t *testing.T) {
+	var plan TerraformPlan
+	if err := json.Unmarshal([]byte(`{"format_version":"1.0","applyable":true}`), &plan); err != nil {
+		t.Fatal(err)
+	}
+	if !plan.Applicable {
+		t.Fatal("expected current applyable field to populate legacy Applicable property")
+	}
+}
+
+func TestTerraformPlanUnmarshalLegacyApplicableField(t *testing.T) {
+	var plan TerraformPlan
+	if err := json.Unmarshal([]byte(`{"format_version":"1.0","applicable":true}`), &plan); err != nil {
+		t.Fatal(err)
+	}
+	if !plan.Applicable {
+		t.Fatal("expected legacy applicable field to remain supported during migration")
+	}
+}

--- a/internal/ir/types.go
+++ b/internal/ir/types.go
@@ -1,0 +1,307 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ir
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const SchemaVersion = "1.0"
+
+type Engine string
+
+const (
+	EngineTerraform Engine = "terraform"
+	EngineOpenTofu  Engine = "opentofu"
+	EngineUnknown   Engine = "unknown-compatible"
+)
+
+type SourceMetadata struct {
+	Engine            Engine `json:"engine"`
+	EngineVersion     string `json:"engine_version,omitempty"`
+	PlanFormatVersion string `json:"plan_format_version"`
+}
+
+type PlanMetadata struct {
+	Applyable bool `json:"applyable"`
+	Complete  bool `json:"complete"`
+	Errored   bool `json:"errored"`
+}
+
+type Address string
+
+type ResourceMode string
+
+const (
+	ResourceModeManaged ResourceMode = "managed"
+	ResourceModeData    ResourceMode = "data"
+)
+
+type ActionKind string
+
+const (
+	ActionNoOp                 ActionKind = "no_op"
+	ActionCreate               ActionKind = "create"
+	ActionUpdate               ActionKind = "update"
+	ActionDelete               ActionKind = "delete"
+	ActionReplaceDestroyCreate ActionKind = "replace_destroy_create"
+	ActionReplaceCreateDestroy ActionKind = "replace_create_destroy"
+	ActionRead                 ActionKind = "read"
+	ActionUnknown              ActionKind = "unknown"
+)
+
+type Action struct {
+	Raw      []string   `json:"raw"`
+	Semantic ActionKind `json:"semantic"`
+}
+
+func NormalizeAction(actions []string) Action {
+	raw := append([]string(nil), actions...)
+	semantic := ActionUnknown
+	switch {
+	case len(actions) == 0 || (len(actions) == 1 && actions[0] == "no-op"):
+		semantic = ActionNoOp
+	case len(actions) == 1 && actions[0] == "create":
+		semantic = ActionCreate
+	case len(actions) == 1 && actions[0] == "update":
+		semantic = ActionUpdate
+	case len(actions) == 1 && actions[0] == "delete":
+		semantic = ActionDelete
+	case len(actions) == 1 && actions[0] == "read":
+		semantic = ActionRead
+	case len(actions) == 2 && actions[0] == "delete" && actions[1] == "create":
+		semantic = ActionReplaceDestroyCreate
+	case len(actions) == 2 && actions[0] == "create" && actions[1] == "delete":
+		semantic = ActionReplaceCreateDestroy
+	}
+	return Action{Raw: raw, Semantic: semantic}
+}
+
+func (a Action) IsReplace() bool {
+	return a.Semantic == ActionReplaceDestroyCreate || a.Semantic == ActionReplaceCreateDestroy
+}
+
+type PathStep struct {
+	Attribute *string `json:"attribute,omitempty"`
+	Index     *string `json:"index,omitempty"`
+}
+
+type AttributePath []PathStep
+
+func Attribute(name string) PathStep { return PathStep{Attribute: &name} }
+func Index(key string) PathStep      { return PathStep{Index: &key} }
+
+func (p AttributePath) String() string {
+	var b strings.Builder
+	for _, step := range p {
+		switch {
+		case step.Attribute != nil:
+			if b.Len() > 0 {
+				b.WriteByte('.')
+			}
+			b.WriteString(*step.Attribute)
+		case step.Index != nil:
+			b.WriteByte('[')
+			b.WriteString(*step.Index)
+			b.WriteByte(']')
+		}
+	}
+	return b.String()
+}
+
+type SafeValue struct {
+	Value    any  `json:"value,omitempty"`
+	Redacted bool `json:"redacted,omitempty"`
+}
+
+type ImportInfo struct {
+	ID      string `json:"id,omitempty"`
+	Unknown bool   `json:"unknown,omitempty"`
+}
+
+type ResourceChange struct {
+	Address         Address         `json:"address"`
+	PreviousAddress *Address        `json:"previous_address,omitempty"`
+	ModuleAddress   *Address        `json:"module_address,omitempty"`
+	Mode            ResourceMode    `json:"mode"`
+	Type            string          `json:"type"`
+	Name            string          `json:"name"`
+	Index           string          `json:"index,omitempty"`
+	DeposedKey      string          `json:"deposed_key,omitempty"`
+	Action          Action          `json:"action"`
+	ActionReason    string          `json:"action_reason,omitempty"`
+	ReplacePaths    []AttributePath `json:"replace_paths,omitempty"`
+	Import          *ImportInfo     `json:"import,omitempty"`
+	Before          SafeValue       `json:"before"`
+	After           SafeValue       `json:"after"`
+	UnknownPaths    []AttributePath `json:"unknown_paths,omitempty"`
+	SensitivePaths  []AttributePath `json:"sensitive_paths,omitempty"`
+}
+
+type OutputChange struct {
+	Name           string          `json:"name"`
+	Action         Action          `json:"action"`
+	UnknownPaths   []AttributePath `json:"unknown_paths,omitempty"`
+	SensitivePaths []AttributePath `json:"sensitive_paths,omitempty"`
+}
+
+type CheckStatus string
+
+const (
+	CheckPass    CheckStatus = "pass"
+	CheckFail    CheckStatus = "fail"
+	CheckError   CheckStatus = "error"
+	CheckUnknown CheckStatus = "unknown"
+)
+
+type CheckProblem struct {
+	Message string `json:"message,omitempty"`
+}
+
+type CheckResult struct {
+	Address  string         `json:"address"`
+	Kind     string         `json:"kind,omitempty"`
+	Status   CheckStatus    `json:"status"`
+	Problems []CheckProblem `json:"problems,omitempty"`
+}
+
+type RelevantAttribute struct {
+	Resource Address       `json:"resource"`
+	Path     AttributePath `json:"path"`
+}
+
+type DriftChange struct {
+	Resource ResourceChange      `json:"resource"`
+	Relevant []RelevantAttribute `json:"relevant,omitempty"`
+}
+
+type EvidenceConfidence string
+
+const (
+	ConfidenceExact     EvidenceConfidence = "exact"
+	ConfidenceStrong    EvidenceConfidence = "strong"
+	ConfidenceHeuristic EvidenceConfidence = "heuristic"
+	ConfidenceUnknown   EvidenceConfidence = "unknown"
+)
+
+type NodeID string
+
+type Node struct {
+	ID      NodeID  `json:"id"`
+	Address Address `json:"address"`
+}
+
+type EdgeKind string
+
+const (
+	EdgeExplicitDependsOn EdgeKind = "explicit_depends_on"
+	EdgeExpressionRef     EdgeKind = "expression_reference"
+	EdgeModuleInput       EdgeKind = "module_input"
+	EdgeModuleOutput      EdgeKind = "module_output"
+	EdgeOutputReference   EdgeKind = "output_reference"
+	EdgeConservative      EdgeKind = "conservative_module_propagation"
+)
+
+type Edge struct {
+	From       NodeID             `json:"from"`
+	To         NodeID             `json:"to"`
+	Kind       EdgeKind           `json:"kind"`
+	Confidence EvidenceConfidence `json:"confidence"`
+}
+
+type DependencyGraph struct {
+	Nodes []Node `json:"nodes,omitempty"`
+	Edges []Edge `json:"edges,omitempty"`
+}
+
+func (g DependencyGraph) DirectDependents(node NodeID) []NodeID {
+	seen := map[NodeID]struct{}{}
+	for _, edge := range g.Edges {
+		if edge.From == node {
+			seen[edge.To] = struct{}{}
+		}
+	}
+	return sortedNodeIDs(seen)
+}
+
+func (g DependencyGraph) TransitiveDependents(node NodeID) []NodeID {
+	seen := map[NodeID]struct{}{}
+	queue := []NodeID{node}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for _, next := range g.DirectDependents(current) {
+			if next == node {
+				continue
+			}
+			if _, ok := seen[next]; ok {
+				continue
+			}
+			seen[next] = struct{}{}
+			queue = append(queue, next)
+		}
+	}
+	return sortedNodeIDs(seen)
+}
+
+func sortedNodeIDs(set map[NodeID]struct{}) []NodeID {
+	out := make([]NodeID, 0, len(set))
+	for id := range set {
+		out = append(out, id)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+type RedactionMode string
+
+const (
+	RedactionStandard RedactionMode = "standard"
+	RedactionStrict   RedactionMode = "strict"
+)
+
+type RedactionSummary struct {
+	Mode                    RedactionMode `json:"mode"`
+	TerraformSensitivePaths int           `json:"terraform_sensitive_paths"`
+	VariableValuesRemoved   int           `json:"variable_values_removed"`
+	StrictValuesRemoved     int           `json:"strict_values_removed,omitempty"`
+}
+
+type ChangeSet struct {
+	SchemaVersion string              `json:"schema_version"`
+	Source        SourceMetadata      `json:"source"`
+	Plan          PlanMetadata        `json:"plan"`
+	Resources     []ResourceChange    `json:"resources,omitempty"`
+	Outputs       []OutputChange      `json:"outputs,omitempty"`
+	Checks        []CheckResult       `json:"checks,omitempty"`
+	Drift         []DriftChange       `json:"drift,omitempty"`
+	Relevant      []RelevantAttribute `json:"relevant,omitempty"`
+	Graph         DependencyGraph     `json:"graph"`
+	Redaction     RedactionSummary    `json:"redaction"`
+}
+
+func (c *ChangeSet) Sort() {
+	sort.Slice(c.Resources, func(i, j int) bool { return c.Resources[i].Address < c.Resources[j].Address })
+	sort.Slice(c.Outputs, func(i, j int) bool { return c.Outputs[i].Name < c.Outputs[j].Name })
+	sort.Slice(c.Checks, func(i, j int) bool { return c.Checks[i].Address < c.Checks[j].Address })
+	sort.Slice(c.Drift, func(i, j int) bool { return c.Drift[i].Resource.Address < c.Drift[j].Resource.Address })
+	sort.Slice(c.Graph.Nodes, func(i, j int) bool { return c.Graph.Nodes[i].ID < c.Graph.Nodes[j].ID })
+	sort.Slice(c.Graph.Edges, func(i, j int) bool {
+		a, b := c.Graph.Edges[i], c.Graph.Edges[j]
+		return fmt.Sprintf("%s:%s:%s", a.From, a.To, a.Kind) < fmt.Sprintf("%s:%s:%s", b.From, b.To, b.Kind)
+	})
+}

--- a/internal/report/format.go
+++ b/internal/report/format.go
@@ -1,0 +1,157 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package report
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type Format string
+
+const (
+	FormatText     Format = "text"
+	FormatJSON     Format = "json"
+	FormatMarkdown Format = "markdown"
+)
+
+func Render(report AnalysisReport, format Format) ([]byte, error) {
+	switch format {
+	case FormatJSON:
+		return renderJSON(report)
+	case FormatMarkdown:
+		return []byte(renderMarkdown(report)), nil
+	case FormatText, "":
+		return []byte(renderText(report)), nil
+	default:
+		return nil, fmt.Errorf("unsupported analysis format %q", format)
+	}
+}
+
+func renderJSON(report AnalysisReport) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(report); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func renderText(report AnalysisReport) string {
+	var b strings.Builder
+	fmt.Fprintln(&b, "Terraform/OpenTofu Change Analysis")
+	fmt.Fprintln(&b, "=================================")
+	fmt.Fprintf(&b, "Engine: %s", report.Source.Engine)
+	if report.Source.EngineVersion != "" {
+		fmt.Fprintf(&b, " %s", report.Source.EngineVersion)
+	}
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "Plan format: %s\n", report.Source.PlanFormatVersion)
+	fmt.Fprintf(&b, "Applyable: %t  Complete: %t  Errored: %t\n\n", report.Plan.Applyable, report.Plan.Complete, report.Plan.Errored)
+	fmt.Fprintf(&b, "Changes: +%d ~%d -%d replace:%d read:%d no-op:%d\n", report.Summary.Create, report.Summary.Update, report.Summary.Delete, report.Summary.Replace, report.Summary.Read, report.Summary.NoOp)
+	fmt.Fprintf(&b, "Findings: critical:%d high:%d medium:%d low:%d info:%d\n", report.Summary.Findings.Critical, report.Summary.Findings.High, report.Summary.Findings.Medium, report.Summary.Findings.Low, report.Summary.Findings.Info)
+	fmt.Fprintf(&b, "Graph: %d nodes, %d edges\n", report.Graph.Nodes, report.Graph.Edges)
+	fmt.Fprintf(&b, "Redaction: %s (%d sensitive paths, %d variable values removed)\n", report.Redaction.Mode, report.Redaction.TerraformSensitivePaths, report.Redaction.VariableValuesRemoved)
+
+	if len(report.Findings) > 0 {
+		fmt.Fprintln(&b, "\nFindings")
+		fmt.Fprintln(&b, "--------")
+		for _, finding := range report.Findings {
+			resource := ""
+			if finding.Resource != nil {
+				resource = " " + finding.Resource.Address
+			}
+			fmt.Fprintf(&b, "[%s] %s%s: %s\n", strings.ToUpper(string(finding.Severity)), finding.RuleID, resource, finding.Message)
+			for _, evidence := range finding.Evidence {
+				if evidence.Path != "" {
+					fmt.Fprintf(&b, "  - %s: %s\n", evidence.Kind, evidence.Path)
+				} else if evidence.Description != "" {
+					fmt.Fprintf(&b, "  - %s: %s\n", evidence.Kind, evidence.Description)
+				}
+			}
+		}
+	}
+
+	if len(report.Changes) > 0 {
+		fmt.Fprintln(&b, "\nChanges")
+		fmt.Fprintln(&b, "-------")
+		for _, change := range report.Changes {
+			fmt.Fprintf(&b, "%s  %s", change.Action, change.Address)
+			if change.ActionReason != "" {
+				fmt.Fprintf(&b, " (%s)", change.ActionReason)
+			}
+			fmt.Fprintln(&b)
+			if len(change.ReplacePaths) > 0 {
+				fmt.Fprintf(&b, "  replacement paths: %s\n", strings.Join(change.ReplacePaths, ", "))
+			}
+			if change.BlastRadius.DirectDependents > 0 || change.BlastRadius.TransitiveDependents > 0 {
+				fmt.Fprintf(&b, "  blast radius: %d direct / %d transitive dependents\n", change.BlastRadius.DirectDependents, change.BlastRadius.TransitiveDependents)
+			}
+		}
+	}
+	return b.String()
+}
+
+func renderMarkdown(report AnalysisReport) string {
+	var b strings.Builder
+	fmt.Fprintln(&b, "## Terraform/OpenTofu change analysis")
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "**Engine:** `%s`  \n", report.Source.Engine)
+	fmt.Fprintf(&b, "**Plan:** applyable `%t`, complete `%t`, errored `%t`  \n", report.Plan.Applyable, report.Plan.Complete, report.Plan.Errored)
+	fmt.Fprintf(&b, "**Changes:** +%d / ~%d / -%d / replace %d  \n", report.Summary.Create, report.Summary.Update, report.Summary.Delete, report.Summary.Replace)
+	fmt.Fprintf(&b, "**Redaction:** `%s`; %d sensitive paths; %d variable values removed\n", report.Redaction.Mode, report.Redaction.TerraformSensitivePaths, report.Redaction.VariableValuesRemoved)
+
+	if len(report.Findings) > 0 {
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, "### Findings")
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, "| Severity | Rule | Resource | Finding |")
+		fmt.Fprintln(&b, "|---|---|---|---|")
+		for _, finding := range report.Findings {
+			resource := ""
+			if finding.Resource != nil {
+				resource = "`" + escapeTable(finding.Resource.Address) + "`"
+			}
+			fmt.Fprintf(&b, "| %s | `%s` | %s | %s |\n", strings.ToUpper(string(finding.Severity)), escapeTable(finding.RuleID), resource, escapeTable(finding.Message))
+		}
+	}
+
+	if len(report.Changes) > 0 {
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, "### Changes")
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, "| Action | Resource | Why / replacement paths | Blast radius |")
+		fmt.Fprintln(&b, "|---|---|---|---:|")
+		for _, change := range report.Changes {
+			why := change.ActionReason
+			if len(change.ReplacePaths) > 0 {
+				if why != "" {
+					why += "; "
+				}
+				why += strings.Join(change.ReplacePaths, ", ")
+			}
+			fmt.Fprintf(&b, "| `%s` | `%s` | %s | %d direct / %d transitive |\n", change.Action, escapeTable(change.Address), escapeTable(why), change.BlastRadius.DirectDependents, change.BlastRadius.TransitiveDependents)
+		}
+	}
+	return b.String()
+}
+
+func escapeTable(value string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(value, "|", "\\|"), "\n", " ")
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1,0 +1,312 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package report
+
+import (
+	"sort"
+
+	"github.com/yu/terraform-ops/internal/ir"
+)
+
+const SchemaVersion = "1.0"
+
+type Severity string
+
+const (
+	SeverityInfo     Severity = "info"
+	SeverityLow      Severity = "low"
+	SeverityMedium   Severity = "medium"
+	SeverityHigh     Severity = "high"
+	SeverityCritical Severity = "critical"
+)
+
+type Confidence string
+
+const (
+	ConfidenceExact     Confidence = "exact"
+	ConfidenceStrong    Confidence = "strong"
+	ConfidenceHeuristic Confidence = "heuristic"
+	ConfidenceUnknown   Confidence = "unknown"
+)
+
+type Category string
+
+const (
+	CategoryPlan        Category = "plan"
+	CategoryLifecycle   Category = "lifecycle"
+	CategoryValidation  Category = "validation"
+	CategoryDrift       Category = "drift"
+	CategorySensitivity Category = "sensitivity"
+	CategoryUncertainty Category = "uncertainty"
+)
+
+type ToolMetadata struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type ResourceRef struct {
+	Address string `json:"address"`
+	Type    string `json:"type,omitempty"`
+}
+
+type Evidence struct {
+	Kind        string `json:"kind"`
+	Description string `json:"description,omitempty"`
+	Path        string `json:"path,omitempty"`
+	Source      string `json:"source,omitempty"`
+}
+
+type Finding struct {
+	RuleID      string       `json:"rule_id"`
+	Title       string       `json:"title"`
+	Category    Category     `json:"category"`
+	Severity    Severity     `json:"severity"`
+	Confidence  Confidence   `json:"confidence"`
+	Resource    *ResourceRef `json:"resource,omitempty"`
+	Evidence    []Evidence   `json:"evidence,omitempty"`
+	Message     string       `json:"message"`
+	Remediation string       `json:"remediation,omitempty"`
+}
+
+type FindingCounts struct {
+	Critical int `json:"critical"`
+	High     int `json:"high"`
+	Medium   int `json:"medium"`
+	Low      int `json:"low"`
+	Info     int `json:"info"`
+}
+
+type Summary struct {
+	Create   int           `json:"create"`
+	Update   int           `json:"update"`
+	Delete   int           `json:"delete"`
+	Replace  int           `json:"replace"`
+	Read     int           `json:"read"`
+	NoOp     int           `json:"no_op"`
+	Unknown  int           `json:"unknown"`
+	Findings FindingCounts `json:"findings"`
+}
+
+type BlastRadius struct {
+	DirectDependents     int `json:"direct_dependents"`
+	TransitiveDependents int `json:"transitive_dependents"`
+}
+
+type ChangeReport struct {
+	Address         string      `json:"address"`
+	PreviousAddress string      `json:"previous_address,omitempty"`
+	Type            string      `json:"type"`
+	Mode            string      `json:"mode"`
+	Action          string      `json:"action"`
+	RawActions      []string    `json:"raw_actions"`
+	ActionReason    string      `json:"action_reason,omitempty"`
+	ReplacePaths    []string    `json:"replace_paths,omitempty"`
+	UnknownPaths    []string    `json:"unknown_paths,omitempty"`
+	SensitivePaths  []string    `json:"sensitive_paths,omitempty"`
+	BlastRadius     BlastRadius `json:"blast_radius"`
+}
+
+type DriftReport struct {
+	Address  string   `json:"address"`
+	Action   string   `json:"action"`
+	Relevant []string `json:"relevant_attributes,omitempty"`
+}
+
+type CheckReport struct {
+	Address string `json:"address"`
+	Kind    string `json:"kind,omitempty"`
+	Status  string `json:"status"`
+}
+
+type GraphSummary struct {
+	Nodes int `json:"nodes"`
+	Edges int `json:"edges"`
+}
+
+type AnalysisReport struct {
+	SchemaVersion string              `json:"schema_version"`
+	Tool          ToolMetadata        `json:"tool"`
+	Source        ir.SourceMetadata   `json:"source"`
+	Plan          ir.PlanMetadata     `json:"plan"`
+	Summary       Summary             `json:"summary"`
+	Findings      []Finding           `json:"findings,omitempty"`
+	Changes       []ChangeReport      `json:"changes,omitempty"`
+	Drift         []DriftReport       `json:"drift,omitempty"`
+	Checks        []CheckReport       `json:"checks,omitempty"`
+	Graph         GraphSummary        `json:"graph"`
+	Redaction     ir.RedactionSummary `json:"redaction"`
+}
+
+func Build(changeSet *ir.ChangeSet, findings []Finding, toolVersion string) AnalysisReport {
+	report := AnalysisReport{
+		SchemaVersion: SchemaVersion,
+		Tool:          ToolMetadata{Name: "terraform-ops", Version: toolVersion},
+		Source:        changeSet.Source,
+		Plan:          changeSet.Plan,
+		Findings:      append([]Finding(nil), findings...),
+		Graph: GraphSummary{
+			Nodes: len(changeSet.Graph.Nodes),
+			Edges: len(changeSet.Graph.Edges),
+		},
+		Redaction: changeSet.Redaction,
+	}
+
+	for _, resource := range changeSet.Resources {
+		switch resource.Action.Semantic {
+		case ir.ActionCreate:
+			report.Summary.Create++
+		case ir.ActionUpdate:
+			report.Summary.Update++
+		case ir.ActionDelete:
+			report.Summary.Delete++
+		case ir.ActionReplaceDestroyCreate, ir.ActionReplaceCreateDestroy:
+			report.Summary.Replace++
+		case ir.ActionRead:
+			report.Summary.Read++
+		case ir.ActionNoOp:
+			report.Summary.NoOp++
+		default:
+			report.Summary.Unknown++
+		}
+
+		change := ChangeReport{
+			Address:        string(resource.Address),
+			Type:           resource.Type,
+			Mode:           string(resource.Mode),
+			Action:         string(resource.Action.Semantic),
+			RawActions:     append([]string(nil), resource.Action.Raw...),
+			ActionReason:   resource.ActionReason,
+			ReplacePaths:   pathStrings(resource.ReplacePaths),
+			UnknownPaths:   pathStrings(resource.UnknownPaths),
+			SensitivePaths: pathStrings(resource.SensitivePaths),
+			BlastRadius: BlastRadius{
+				DirectDependents:     len(changeSet.Graph.DirectDependents(ir.NodeID(resource.Address))),
+				TransitiveDependents: len(changeSet.Graph.TransitiveDependents(ir.NodeID(resource.Address))),
+			},
+		}
+		if resource.PreviousAddress != nil {
+			change.PreviousAddress = string(*resource.PreviousAddress)
+		}
+		report.Changes = append(report.Changes, change)
+	}
+
+	for _, drift := range changeSet.Drift {
+		item := DriftReport{
+			Address: string(drift.Resource.Address),
+			Action:  string(drift.Resource.Action.Semantic),
+		}
+		for _, relevant := range drift.Relevant {
+			item.Relevant = append(item.Relevant, relevant.Path.String())
+		}
+		sort.Strings(item.Relevant)
+		report.Drift = append(report.Drift, item)
+	}
+
+	for _, check := range changeSet.Checks {
+		report.Checks = append(report.Checks, CheckReport{
+			Address: check.Address,
+			Kind:    check.Kind,
+			Status:  string(check.Status),
+		})
+	}
+
+	for _, finding := range report.Findings {
+		switch finding.Severity {
+		case SeverityCritical:
+			report.Summary.Findings.Critical++
+		case SeverityHigh:
+			report.Summary.Findings.High++
+		case SeverityMedium:
+			report.Summary.Findings.Medium++
+		case SeverityLow:
+			report.Summary.Findings.Low++
+		case SeverityInfo:
+			report.Summary.Findings.Info++
+		}
+	}
+
+	Sort(&report)
+	return report
+}
+
+func Sort(report *AnalysisReport) {
+	sort.Slice(report.Findings, func(i, j int) bool {
+		a, b := report.Findings[i], report.Findings[j]
+		if severityRank(a.Severity) != severityRank(b.Severity) {
+			return severityRank(a.Severity) > severityRank(b.Severity)
+		}
+		if a.RuleID != b.RuleID {
+			return a.RuleID < b.RuleID
+		}
+		return resourceAddress(a.Resource) < resourceAddress(b.Resource)
+	})
+	sort.Slice(report.Changes, func(i, j int) bool { return report.Changes[i].Address < report.Changes[j].Address })
+	sort.Slice(report.Drift, func(i, j int) bool { return report.Drift[i].Address < report.Drift[j].Address })
+	sort.Slice(report.Checks, func(i, j int) bool { return report.Checks[i].Address < report.Checks[j].Address })
+}
+
+func HighestSeverity(findings []Finding) Severity {
+	highest := SeverityInfo
+	if len(findings) == 0 {
+		return ""
+	}
+	for _, finding := range findings {
+		if severityRank(finding.Severity) > severityRank(highest) {
+			highest = finding.Severity
+		}
+	}
+	return highest
+}
+
+func MeetsThreshold(severity, threshold Severity) bool {
+	if threshold == "" {
+		return false
+	}
+	return severityRank(severity) >= severityRank(threshold)
+}
+
+func severityRank(severity Severity) int {
+	switch severity {
+	case SeverityCritical:
+		return 5
+	case SeverityHigh:
+		return 4
+	case SeverityMedium:
+		return 3
+	case SeverityLow:
+		return 2
+	case SeverityInfo:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func resourceAddress(resource *ResourceRef) string {
+	if resource == nil {
+		return ""
+	}
+	return resource.Address
+}
+
+func pathStrings(paths []ir.AttributePath) []string {
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		out = append(out, path.String())
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/source/terraform/compat.go
+++ b/internal/source/terraform/compat.go
@@ -1,0 +1,58 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terraform
+
+import (
+	"strconv"
+	"strings"
+)
+
+func planComplete(plan *Plan) bool {
+	if plan.Complete != nil {
+		return *plan.Complete
+	}
+
+	major, minor, ok := parseMajorMinorVersion(plan.TerraformVersion)
+	if !ok {
+		// Missing completeness metadata is ambiguous for unknown/current
+		// producers. Stay conservative unless the producer version proves that
+		// the field predates Terraform 1.8.
+		return false
+	}
+	return major < 1 || (major == 1 && minor < 8)
+}
+
+func parseMajorMinorVersion(version string) (int, int, bool) {
+	version = strings.TrimSpace(strings.TrimPrefix(version, "v"))
+	if version == "" {
+		return 0, 0, false
+	}
+	if core, _, ok := strings.Cut(version, "-"); ok {
+		version = core
+	}
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, false
+	}
+	return major, minor, true
+}

--- a/internal/source/terraform/graph_modules.go
+++ b/internal/source/terraform/graph_modules.go
@@ -33,12 +33,14 @@ type configResourceContext struct {
 }
 
 func buildDependencyGraphWithModules(configuration Configuration, resources []ir.ResourceChange) ir.DependencyGraph {
-	graph := ir.DependencyGraph{}
+	// Preserve the existing resource-level graph as the baseline, then augment
+	// it with module-aware edges. This keeps the established depends_on and
+	// expression-reference behavior while adding module input/output traversal.
+	graph := buildDependencyGraph(configuration, resources)
 	changed := make(map[string]ir.NodeID, len(resources))
 	for _, resource := range resources {
 		id := ir.NodeID(resource.Address)
 		changed[string(resource.Address)] = id
-		graph.Nodes = append(graph.Nodes, ir.Node{ID: id, Address: resource.Address})
 	}
 
 	contexts := flattenConfigResourceContexts(configuration.RootModule)
@@ -52,7 +54,10 @@ func buildDependencyGraphWithModules(configuration Configuration, resources []ir
 		baseToChanges[context.address] = uniqueNodeIDs(baseToChanges[context.address])
 	}
 
-	edges := make(map[string]ir.Edge)
+	edges := make(map[string]ir.Edge, len(graph.Edges))
+	for _, edge := range graph.Edges {
+		addEdge(edges, edge.From, edge.To, edge.Kind, edge.Confidence)
+	}
 
 	// Evaluate resource-level references with module context. Configuration
 	// expressions inside child modules use addresses relative to that module.
@@ -101,6 +106,7 @@ func buildDependencyGraphWithModules(configuration Configuration, resources []ir
 		edges,
 	)
 
+	graph.Edges = graph.Edges[:0]
 	for _, edge := range edges {
 		graph.Edges = append(graph.Edges, edge)
 	}

--- a/internal/source/terraform/graph_modules.go
+++ b/internal/source/terraform/graph_modules.go
@@ -1,0 +1,478 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terraform
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/yu/terraform-ops/internal/ir"
+)
+
+type graphSource struct {
+	id         ir.NodeID
+	confidence ir.EvidenceConfidence
+}
+
+type configResourceContext struct {
+	modulePath string
+	address    string
+	resource   ConfigResource
+}
+
+func buildDependencyGraphWithModules(configuration Configuration, resources []ir.ResourceChange) ir.DependencyGraph {
+	graph := ir.DependencyGraph{}
+	changed := make(map[string]ir.NodeID, len(resources))
+	for _, resource := range resources {
+		id := ir.NodeID(resource.Address)
+		changed[string(resource.Address)] = id
+		graph.Nodes = append(graph.Nodes, ir.Node{ID: id, Address: resource.Address})
+	}
+
+	contexts := flattenConfigResourceContexts(configuration.RootModule)
+	baseToChanges := make(map[string][]ir.NodeID)
+	for _, context := range contexts {
+		for address, id := range changed {
+			if stripAddressIndexes(address) == stripAddressIndexes(context.address) {
+				baseToChanges[context.address] = append(baseToChanges[context.address], id)
+			}
+		}
+		baseToChanges[context.address] = uniqueNodeIDs(baseToChanges[context.address])
+	}
+
+	edges := make(map[string]ir.Edge)
+
+	// Evaluate resource-level references with module context. Configuration
+	// expressions inside child modules use addresses relative to that module.
+	for _, context := range contexts {
+		targets := baseToChanges[context.address]
+		if len(targets) == 0 {
+			continue
+		}
+		for _, dependency := range context.resource.DependsOn {
+			if strings.HasPrefix(stripAddressIndexes(dependency), "module.") {
+				childPath := referencedChildModulePath(context.modulePath, dependency)
+				for _, source := range changedSourcesUnderModule(childPath, changed, ir.ConfidenceExact) {
+					addSourcesToTargets(edges, []graphSource{source}, targets, ir.EdgeExplicitDependsOn)
+				}
+				continue
+			}
+			reference := qualifyResourceReference(context.modulePath, dependency)
+			for _, source := range resolveReference(reference, changed, baseToChanges) {
+				for _, target := range targets {
+					addEdge(edges, source, target, ir.EdgeExplicitDependsOn, ir.ConfidenceExact)
+				}
+			}
+		}
+		for _, rawExpression := range context.resource.Expressions {
+			for _, reference := range extractReferences(rawExpression) {
+				normalized := stripAddressIndexes(reference)
+				if strings.HasPrefix(normalized, "var.") || strings.HasPrefix(normalized, "module.") {
+					continue
+				}
+				reference = qualifyResourceReference(context.modulePath, reference)
+				for _, source := range resolveReference(reference, changed, baseToChanges) {
+					for _, target := range targets {
+						addEdge(edges, source, target, ir.EdgeExpressionRef, ir.ConfidenceExact)
+					}
+				}
+			}
+		}
+	}
+
+	addModuleBoundaryEdges(
+		configuration.RootModule,
+		"",
+		nil,
+		changed,
+		baseToChanges,
+		edges,
+	)
+
+	for _, edge := range edges {
+		graph.Edges = append(graph.Edges, edge)
+	}
+	return graph
+}
+
+func addModuleBoundaryEdges(
+	module Module,
+	modulePath string,
+	inputs map[string][]graphSource,
+	changed map[string]ir.NodeID,
+	baseToChanges map[string][]ir.NodeID,
+	edges map[string]ir.Edge,
+) map[string][]graphSource {
+	childOutputs := make(map[string][]graphSource)
+
+	names := make([]string, 0, len(module.ModuleCalls))
+	for name := range module.ModuleCalls {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		call := module.ModuleCalls[name]
+		childPath := appendModulePath(modulePath, name)
+		childInputs := make(map[string][]graphSource, len(call.Expressions))
+		for inputName, rawExpression := range call.Expressions {
+			var sources []graphSource
+			for _, reference := range extractReferences(rawExpression) {
+				sources = append(sources, resolveBoundaryReference(
+					reference,
+					modulePath,
+					inputs,
+					childOutputs,
+					changed,
+					baseToChanges,
+				)...)
+			}
+			childInputs[inputName] = uniqueGraphSources(sources)
+		}
+		if call.Module == nil {
+			continue
+		}
+		for outputRef, sources := range addModuleBoundaryEdges(
+			*call.Module,
+			childPath,
+			childInputs,
+			changed,
+			baseToChanges,
+			edges,
+		) {
+			childOutputs[outputRef] = uniqueGraphSources(append(childOutputs[outputRef], sources...))
+		}
+	}
+
+	for _, resource := range module.Resources {
+		address := qualifyConfigResourceAddress(modulePath, resource.Address)
+		targets := baseToChanges[address]
+		if len(targets) == 0 {
+			continue
+		}
+		for _, rawExpression := range resource.Expressions {
+			for _, reference := range extractReferences(rawExpression) {
+				normalized := stripAddressIndexes(reference)
+				switch {
+				case strings.HasPrefix(normalized, "var."):
+					name := variableReferenceName(normalized)
+					addSourcesToTargets(edges, inputs[name], targets, ir.EdgeModuleInput)
+				case strings.HasPrefix(normalized, "module."):
+					sources := resolveBoundaryReference(
+						reference,
+						modulePath,
+						inputs,
+						childOutputs,
+						changed,
+						baseToChanges,
+					)
+					addSourcesToTargets(edges, sources, targets, ir.EdgeModuleOutput)
+				}
+			}
+		}
+	}
+
+	outputs := make(map[string][]graphSource, len(module.Outputs))
+	outputNames := make([]string, 0, len(module.Outputs))
+	for name := range module.Outputs {
+		outputNames = append(outputNames, name)
+	}
+	sort.Strings(outputNames)
+	for _, name := range outputNames {
+		rawOutput := module.Outputs[name]
+		var sources []graphSource
+		for _, reference := range extractReferences(rawOutput.Expression) {
+			sources = append(sources, resolveBoundaryReference(
+				reference,
+				modulePath,
+				inputs,
+				childOutputs,
+				changed,
+				baseToChanges,
+			)...)
+		}
+		outputs[moduleOutputReference(modulePath, name)] = uniqueGraphSources(sources)
+	}
+	return outputs
+}
+
+func resolveBoundaryReference(
+	reference string,
+	modulePath string,
+	inputs map[string][]graphSource,
+	childOutputs map[string][]graphSource,
+	changed map[string]ir.NodeID,
+	baseToChanges map[string][]ir.NodeID,
+) []graphSource {
+	normalized := stripAddressIndexes(reference)
+	if strings.HasPrefix(normalized, "var.") {
+		return append([]graphSource(nil), inputs[variableReferenceName(normalized)]...)
+	}
+	if strings.HasPrefix(normalized, "module.") {
+		absolute := absoluteModuleReference(modulePath, normalized)
+		if sources := resolveModuleOutputReference(absolute, childOutputs); len(sources) > 0 {
+			return sources
+		}
+		// If Terraform's expression representation does not let us attribute the
+		// output to a specific changed resource, prefer conservative propagation
+		// over understating blast radius.
+		childPath := referencedChildModulePath(modulePath, normalized)
+		return changedSourcesUnderModule(childPath, changed, ir.ConfidenceHeuristic)
+	}
+
+	qualified := qualifyResourceReference(modulePath, reference)
+	ids := resolveReference(qualified, changed, baseToChanges)
+	sources := make([]graphSource, 0, len(ids))
+	for _, id := range ids {
+		sources = append(sources, graphSource{id: id, confidence: ir.ConfidenceExact})
+	}
+	return sources
+}
+
+func resolveModuleOutputReference(reference string, outputs map[string][]graphSource) []graphSource {
+	var best string
+	for outputRef := range outputs {
+		if referenceHasAddressPrefix(reference, outputRef) && len(outputRef) > len(best) {
+			best = outputRef
+		}
+	}
+	if best == "" {
+		return nil
+	}
+	return append([]graphSource(nil), outputs[best]...)
+}
+
+func addSourcesToTargets(
+	edges map[string]ir.Edge,
+	sources []graphSource,
+	targets []ir.NodeID,
+	kind ir.EdgeKind,
+) {
+	for _, source := range uniqueGraphSources(sources) {
+		for _, target := range targets {
+			addEdge(edges, source.id, target, kind, source.confidence)
+		}
+	}
+}
+
+func flattenConfigResourceContexts(root Module) []configResourceContext {
+	var out []configResourceContext
+	var visit func(Module, string)
+	visit = func(module Module, modulePath string) {
+		for _, resource := range module.Resources {
+			out = append(out, configResourceContext{
+				modulePath: modulePath,
+				address:    qualifyConfigResourceAddress(modulePath, resource.Address),
+				resource:   resource,
+			})
+		}
+		names := make([]string, 0, len(module.ModuleCalls))
+		for name := range module.ModuleCalls {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			call := module.ModuleCalls[name]
+			if call.Module != nil {
+				visit(*call.Module, appendModulePath(modulePath, name))
+			}
+		}
+	}
+	visit(root, "")
+	return out
+}
+
+func qualifyConfigResourceAddress(modulePath, address string) string {
+	if modulePath == "" {
+		return address
+	}
+	normalized := stripAddressIndexes(address)
+	if strings.HasPrefix(normalized, modulePath+".") {
+		return address
+	}
+	return modulePath + "." + address
+}
+
+func qualifyResourceReference(modulePath, reference string) string {
+	if modulePath == "" || !isRelativeResourceReference(reference) {
+		return reference
+	}
+	normalized := stripAddressIndexes(reference)
+	if strings.HasPrefix(normalized, modulePath+".") {
+		return reference
+	}
+	return modulePath + "." + reference
+}
+
+func isRelativeResourceReference(reference string) bool {
+	normalized := stripAddressIndexes(reference)
+	for _, prefix := range []string{
+		"var.", "local.", "module.", "path.", "terraform.", "count.", "each.",
+	} {
+		if strings.HasPrefix(normalized, prefix) {
+			return false
+		}
+	}
+	return normalized != "self"
+}
+
+func appendModulePath(parent, name string) string {
+	child := "module." + name
+	if parent == "" {
+		return child
+	}
+	return parent + "." + child
+}
+
+func absoluteModuleReference(modulePath, reference string) string {
+	if modulePath == "" {
+		return reference
+	}
+	if strings.HasPrefix(reference, modulePath+".") {
+		return reference
+	}
+	return modulePath + "." + reference
+}
+
+func referencedChildModulePath(modulePath, reference string) string {
+	normalized := stripAddressIndexes(reference)
+	if !strings.HasPrefix(normalized, "module.") {
+		return ""
+	}
+	rest := strings.TrimPrefix(normalized, "module.")
+	name, _, _ := strings.Cut(rest, ".")
+	if name == "" {
+		return ""
+	}
+	return appendModulePath(modulePath, name)
+}
+
+func moduleOutputReference(modulePath, outputName string) string {
+	if modulePath == "" {
+		return outputName
+	}
+	return modulePath + "." + outputName
+}
+
+func variableReferenceName(reference string) string {
+	rest := strings.TrimPrefix(reference, "var.")
+	name, _, _ := strings.Cut(rest, ".")
+	return name
+}
+
+func changedSourcesUnderModule(
+	modulePath string,
+	changed map[string]ir.NodeID,
+	confidence ir.EvidenceConfidence,
+) []graphSource {
+	if modulePath == "" {
+		return nil
+	}
+	var sources []graphSource
+	for address, id := range changed {
+		normalized := stripAddressIndexes(address)
+		if strings.HasPrefix(normalized, modulePath+".") {
+			sources = append(sources, graphSource{id: id, confidence: confidence})
+		}
+	}
+	return uniqueGraphSources(sources)
+}
+
+func stripAddressIndexes(address string) string {
+	var out strings.Builder
+	out.Grow(len(address))
+
+	inIndex := false
+	inString := false
+	escaped := false
+	for i := 0; i < len(address); i++ {
+		ch := address[i]
+		if !inIndex {
+			if ch == '[' {
+				inIndex = true
+				continue
+			}
+			out.WriteByte(ch)
+			continue
+		}
+
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inString && ch == '\\' {
+			escaped = true
+			continue
+		}
+		if ch == '"' {
+			inString = !inString
+			continue
+		}
+		if ch == ']' && !inString {
+			inIndex = false
+		}
+	}
+	return out.String()
+}
+
+func uniqueGraphSources(sources []graphSource) []graphSource {
+	byID := make(map[ir.NodeID]ir.EvidenceConfidence, len(sources))
+	for _, source := range sources {
+		if source.id == "" {
+			continue
+		}
+		if current, ok := byID[source.id]; !ok || confidenceRank(source.confidence) > confidenceRank(current) {
+			byID[source.id] = source.confidence
+		}
+	}
+	ids := make([]ir.NodeID, 0, len(byID))
+	for id := range byID {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	out := make([]graphSource, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, graphSource{id: id, confidence: byID[id]})
+	}
+	return out
+}
+
+func uniqueNodeIDs(ids []ir.NodeID) []ir.NodeID {
+	set := make(map[ir.NodeID]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	out := make([]ir.NodeID, 0, len(set))
+	for id := range set {
+		out = append(out, id)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+func confidenceRank(confidence ir.EvidenceConfidence) int {
+	switch confidence {
+	case ir.ConfidenceExact:
+		return 4
+	case ir.ConfidenceStrong:
+		return 3
+	case ir.ConfidenceHeuristic:
+		return 2
+	case ir.ConfidenceUnknown:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/source/terraform/normalize.go
+++ b/internal/source/terraform/normalize.go
@@ -44,7 +44,7 @@ func Normalize(plan *Plan, engine ir.Engine, mode ir.RedactionMode) (*ir.ChangeS
 		},
 		Plan: ir.PlanMetadata{
 			Applyable: plan.Applyable,
-			Complete:  plan.Complete,
+			Complete:  planComplete(plan),
 			Errored:   plan.Errored,
 		},
 		Redaction: ir.RedactionSummary{
@@ -104,7 +104,7 @@ func Normalize(plan *Plan, engine ir.Engine, mode ir.RedactionMode) (*ir.ChangeS
 		})
 	}
 
-	out.Graph = buildDependencyGraph(plan.Configuration, out.Resources)
+	out.Graph = buildDependencyGraphWithModules(plan.Configuration, out.Resources)
 	out.Sort()
 	return out, nil
 }

--- a/internal/source/terraform/normalize.go
+++ b/internal/source/terraform/normalize.go
@@ -531,7 +531,8 @@ func walkReferences(value any, refs map[string]struct{}) {
 						if ref, ok := value.(string); ok {
 							refs[ref] = struct{}{}
 						}
-				}
+					}
+			}
 			}
 			walkReferences(child, refs)
 		}

--- a/internal/source/terraform/normalize.go
+++ b/internal/source/terraform/normalize.go
@@ -464,9 +464,46 @@ func resolveReference(reference string, changed map[string]ir.NodeID, baseToChan
 		return []ir.NodeID{id}
 	}
 	if ids, ok := baseToChanges[reference]; ok {
-		return ids
+		return append([]ir.NodeID(nil), ids...)
 	}
-	return nil
+
+	// Expression references commonly include an attribute traversal (for example,
+	// aws_instance.web.id) while graph nodes are resource-instance addresses.
+	// Match only at Terraform address boundaries so similarly-prefixed resources
+	// such as foo and foobar are never conflated. Prefer the longest matching
+	// address and return its instances when the reference targets an unkeyed
+	// resource address.
+	type candidate struct {
+		address string
+		ids     []ir.NodeID
+	}
+	var best candidate
+	for address, id := range changed {
+		if referenceHasAddressPrefix(reference, address) && len(address) > len(best.address) {
+			best = candidate{address: address, ids: []ir.NodeID{id}}
+		}
+	}
+	for address, ids := range baseToChanges {
+		if referenceHasAddressPrefix(reference, address) && len(address) > len(best.address) {
+			best = candidate{address: address, ids: append([]ir.NodeID(nil), ids...)}
+		}
+	}
+	return best.ids
+}
+
+func referenceHasAddressPrefix(reference, address string) bool {
+	if reference == address {
+		return true
+	}
+	if !strings.HasPrefix(reference, address) || len(reference) == len(address) {
+		return false
+	}
+	switch reference[len(address)] {
+	case '.', '[':
+		return true
+	default:
+		return false
+	}
 }
 
 func extractReferences(raw json.RawMessage) []string {
@@ -494,7 +531,6 @@ func walkReferences(value any, refs map[string]struct{}) {
 						if ref, ok := value.(string); ok {
 							refs[ref] = struct{}{}
 						}
-					}
 				}
 			}
 			walkReferences(child, refs)

--- a/internal/source/terraform/normalize.go
+++ b/internal/source/terraform/normalize.go
@@ -532,7 +532,7 @@ func walkReferences(value any, refs map[string]struct{}) {
 							refs[ref] = struct{}{}
 						}
 					}
-			}
+				}
 			}
 			walkReferences(child, refs)
 		}

--- a/internal/source/terraform/normalize.go
+++ b/internal/source/terraform/normalize.go
@@ -1,0 +1,507 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terraform
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/yu/terraform-ops/internal/ir"
+)
+
+func Normalize(plan *Plan, engine ir.Engine, mode ir.RedactionMode) (*ir.ChangeSet, error) {
+	if plan == nil {
+		return nil, fmt.Errorf("plan is nil")
+	}
+	if engine == "" {
+		engine = ir.EngineUnknown
+	}
+	if mode == "" {
+		mode = ir.RedactionStandard
+	}
+
+	out := &ir.ChangeSet{
+		SchemaVersion: ir.SchemaVersion,
+		Source: ir.SourceMetadata{
+			Engine:            engine,
+			EngineVersion:     plan.TerraformVersion,
+			PlanFormatVersion: plan.FormatVersion,
+		},
+		Plan: ir.PlanMetadata{
+			Applyable: plan.Applyable,
+			Complete:  plan.Complete,
+			Errored:   plan.Errored,
+		},
+		Redaction: ir.RedactionSummary{
+			Mode:                  mode,
+			VariableValuesRemoved: len(plan.Variables),
+		},
+	}
+
+	for _, raw := range plan.ResourceChanges {
+		change, count, strictCount, err := normalizeResourceChange(raw, mode)
+		if err != nil {
+			return nil, fmt.Errorf("normalize resource %q: %w", raw.Address, err)
+		}
+		out.Resources = append(out.Resources, change)
+		out.Redaction.TerraformSensitivePaths += count
+		out.Redaction.StrictValuesRemoved += strictCount
+	}
+
+	for name, raw := range plan.OutputChanges {
+		output, count, err := normalizeOutputChange(name, raw)
+		if err != nil {
+			return nil, fmt.Errorf("normalize output %q: %w", name, err)
+		}
+		out.Outputs = append(out.Outputs, output)
+		out.Redaction.TerraformSensitivePaths += count
+	}
+
+	for _, check := range plan.Checks {
+		out.Checks = append(out.Checks, normalizeCheck(check, mode)...)
+	}
+
+	for _, relevant := range plan.RelevantAttributes {
+		path, err := parsePathRaw(relevant.Attribute)
+		if err != nil {
+			return nil, fmt.Errorf("normalize relevant attribute %q: %w", relevant.Resource, err)
+		}
+		out.Relevant = append(out.Relevant, ir.RelevantAttribute{
+			Resource: ir.Address(relevant.Resource),
+			Path:     path,
+		})
+	}
+
+	relevantByResource := make(map[ir.Address][]ir.RelevantAttribute)
+	for _, relevant := range out.Relevant {
+		relevantByResource[relevant.Resource] = append(relevantByResource[relevant.Resource], relevant)
+	}
+	for _, raw := range plan.ResourceDrift {
+		change, count, strictCount, err := normalizeResourceChange(raw, mode)
+		if err != nil {
+			return nil, fmt.Errorf("normalize drift resource %q: %w", raw.Address, err)
+		}
+		out.Redaction.TerraformSensitivePaths += count
+		out.Redaction.StrictValuesRemoved += strictCount
+		out.Drift = append(out.Drift, ir.DriftChange{
+			Resource: change,
+			Relevant: relevantByResource[change.Address],
+		})
+	}
+
+	out.Graph = buildDependencyGraph(plan.Configuration, out.Resources)
+	out.Sort()
+	return out, nil
+}
+
+func normalizeResourceChange(raw ResourceChange, mode ir.RedactionMode) (ir.ResourceChange, int, int, error) {
+	before, beforePaths, beforeStrict, err := sanitizeValue(raw.Change.Before, raw.Change.BeforeSensitive, mode)
+	if err != nil {
+		return ir.ResourceChange{}, 0, 0, fmt.Errorf("sanitize before value: %w", err)
+	}
+	after, afterPaths, afterStrict, err := sanitizeValue(raw.Change.After, raw.Change.AfterSensitive, mode)
+	if err != nil {
+		return ir.ResourceChange{}, 0, 0, fmt.Errorf("sanitize after value: %w", err)
+	}
+	unknown, err := collectMaskPaths(raw.Change.AfterUnknown)
+	if err != nil {
+		return ir.ResourceChange{}, 0, 0, fmt.Errorf("collect unknown paths: %w", err)
+	}
+	replacePaths := make([]ir.AttributePath, 0, len(raw.Change.ReplacePaths))
+	for _, replacePath := range raw.Change.ReplacePaths {
+		path, err := parsePathRaw(replacePath)
+		if err != nil {
+			return ir.ResourceChange{}, 0, 0, fmt.Errorf("parse replacement path: %w", err)
+		}
+		replacePaths = append(replacePaths, path)
+	}
+
+	change := ir.ResourceChange{
+		Address:        ir.Address(raw.Address),
+		Mode:           ir.ResourceMode(raw.Mode),
+		Type:           raw.Type,
+		Name:           raw.Name,
+		DeposedKey:     raw.Deposed,
+		Action:         ir.NormalizeAction(raw.Change.Actions),
+		ActionReason:   raw.ActionReason,
+		ReplacePaths:   replacePaths,
+		Before:         before,
+		After:          after,
+		UnknownPaths:   uniquePaths(unknown),
+		SensitivePaths: uniquePaths(append(beforePaths, afterPaths...)),
+	}
+	if raw.PreviousAddress != "" {
+		addr := ir.Address(raw.PreviousAddress)
+		change.PreviousAddress = &addr
+	}
+	if raw.ModuleAddress != "" {
+		addr := ir.Address(raw.ModuleAddress)
+		change.ModuleAddress = &addr
+	}
+	if len(raw.Index) > 0 {
+		index, err := decodeJSON(raw.Index)
+		if err != nil {
+			return ir.ResourceChange{}, 0, 0, fmt.Errorf("decode instance index: %w", err)
+		}
+		change.Index = fmt.Sprint(index)
+	}
+	if raw.Change.Importing != nil {
+		change.Import = &ir.ImportInfo{ID: raw.Change.Importing.ID, Unknown: raw.Change.Importing.Unknown}
+	}
+	return change, len(change.SensitivePaths), beforeStrict + afterStrict, nil
+}
+
+func normalizeOutputChange(name string, raw OutputChange) (ir.OutputChange, int, error) {
+	before, err := collectMaskPaths(raw.Change.BeforeSensitive)
+	if err != nil {
+		return ir.OutputChange{}, 0, err
+	}
+	after, err := collectMaskPaths(raw.Change.AfterSensitive)
+	if err != nil {
+		return ir.OutputChange{}, 0, err
+	}
+	unknown, err := collectMaskPaths(raw.Change.AfterUnknown)
+	if err != nil {
+		return ir.OutputChange{}, 0, err
+	}
+	sensitive := uniquePaths(append(before, after...))
+	return ir.OutputChange{
+		Name:           name,
+		Action:         ir.NormalizeAction(raw.Change.Actions),
+		UnknownPaths:   uniquePaths(unknown),
+		SensitivePaths: sensitive,
+	}, len(sensitive), nil
+}
+
+func normalizeCheck(raw Check, mode ir.RedactionMode) []ir.CheckResult {
+	if len(raw.Instances) == 0 {
+		return []ir.CheckResult{{
+			Address: raw.Address.ToDisplay,
+			Kind:    raw.Address.Kind,
+			Status:  ir.CheckStatus(raw.Status),
+		}}
+	}
+	results := make([]ir.CheckResult, 0, len(raw.Instances))
+	for _, instance := range raw.Instances {
+		result := ir.CheckResult{
+			Address: instance.Address.ToDisplay,
+			Kind:    raw.Address.Kind,
+			Status:  ir.CheckStatus(instance.Status),
+		}
+		if result.Address == "" {
+			result.Address = raw.Address.ToDisplay
+		}
+		if mode != ir.RedactionStrict {
+			for _, problem := range instance.Problems {
+				result.Problems = append(result.Problems, ir.CheckProblem{Message: problem.Message})
+			}
+		}
+		results = append(results, result)
+	}
+	return results
+}
+
+func sanitizeValue(valueRaw, maskRaw json.RawMessage, mode ir.RedactionMode) (ir.SafeValue, []ir.AttributePath, int, error) {
+	paths, err := collectMaskPaths(maskRaw)
+	if err != nil {
+		return ir.SafeValue{}, nil, 0, err
+	}
+	if mode == ir.RedactionStrict {
+		if len(valueRaw) == 0 || string(valueRaw) == "null" {
+			return ir.SafeValue{}, paths, 0, nil
+		}
+		return ir.SafeValue{Redacted: true}, paths, 1, nil
+	}
+	value, err := decodeJSON(valueRaw)
+	if err != nil {
+		return ir.SafeValue{}, nil, 0, err
+	}
+	mask, err := decodeJSON(maskRaw)
+	if err != nil {
+		return ir.SafeValue{}, nil, 0, err
+	}
+	redacted, fullyRedacted := applyMask(value, mask)
+	return ir.SafeValue{Value: redacted, Redacted: fullyRedacted}, paths, 0, nil
+}
+
+func applyMask(value, mask any) (any, bool) {
+	if sensitive, ok := mask.(bool); ok && sensitive {
+		return nil, true
+	}
+	if mask == nil {
+		return value, false
+	}
+
+	switch typedMask := mask.(type) {
+	case map[string]any:
+		valueMap, ok := value.(map[string]any)
+		if !ok {
+			return value, false
+		}
+		out := make(map[string]any, len(valueMap))
+		for key, item := range valueMap {
+			childMask := typedMask[key]
+			child, redacted := applyMask(item, childMask)
+			if redacted {
+				out[key] = "<redacted>"
+			} else {
+				out[key] = child
+			}
+		}
+		return out, false
+	case []any:
+		valueSlice, ok := value.([]any)
+		if !ok {
+			return value, false
+		}
+		out := make([]any, len(valueSlice))
+		for i, item := range valueSlice {
+			var childMask any
+			if i < len(typedMask) {
+				childMask = typedMask[i]
+			}
+			child, redacted := applyMask(item, childMask)
+			if redacted {
+				out[i] = "<redacted>"
+			} else {
+				out[i] = child
+			}
+		}
+		return out, false
+	default:
+		return value, false
+	}
+}
+
+func collectMaskPaths(raw json.RawMessage) ([]ir.AttributePath, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	value, err := decodeJSON(raw)
+	if err != nil {
+		return nil, err
+	}
+	var paths []ir.AttributePath
+	walkMask(value, nil, &paths)
+	return paths, nil
+}
+
+func walkMask(value any, path ir.AttributePath, paths *[]ir.AttributePath) {
+	switch typed := value.(type) {
+	case bool:
+		if typed {
+			copyPath := append(ir.AttributePath(nil), path...)
+			*paths = append(*paths, copyPath)
+		}
+	case map[string]any:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			walkMask(typed[key], appendPath(path, ir.Attribute(key)), paths)
+		}
+	case []any:
+		for i, item := range typed {
+			walkMask(item, appendPath(path, ir.Index(strconv.Itoa(i))), paths)
+		}
+	}
+}
+
+func parsePathRaw(raw json.RawMessage) (ir.AttributePath, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	value, err := decodeJSON(raw)
+	if err != nil {
+		return nil, err
+	}
+	return parsePathValue(value)
+}
+
+func parsePathValue(value any) (ir.AttributePath, error) {
+	switch typed := value.(type) {
+	case string:
+		return ir.AttributePath{ir.Attribute(typed)}, nil
+	case []any:
+		path := make(ir.AttributePath, 0, len(typed))
+		for _, step := range typed {
+			switch v := step.(type) {
+			case string:
+				path = append(path, ir.Attribute(v))
+			case json.Number:
+				path = append(path, ir.Index(v.String()))
+			case float64:
+				path = append(path, ir.Index(strconv.FormatFloat(v, 'f', -1, 64)))
+			default:
+				return nil, fmt.Errorf("unsupported path step type %T", step)
+			}
+		}
+		return path, nil
+	default:
+		return nil, fmt.Errorf("unsupported path type %T", value)
+	}
+}
+
+func appendPath(path ir.AttributePath, step ir.PathStep) ir.AttributePath {
+	out := make(ir.AttributePath, len(path), len(path)+1)
+	copy(out, path)
+	return append(out, step)
+}
+
+func uniquePaths(paths []ir.AttributePath) []ir.AttributePath {
+	seen := make(map[string]ir.AttributePath)
+	for _, path := range paths {
+		seen[path.String()] = path
+	}
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]ir.AttributePath, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, seen[key])
+	}
+	return out
+}
+
+func buildDependencyGraph(configuration Configuration, resources []ir.ResourceChange) ir.DependencyGraph {
+	graph := ir.DependencyGraph{}
+	changed := make(map[string]ir.NodeID, len(resources))
+	for _, resource := range resources {
+		id := ir.NodeID(resource.Address)
+		changed[string(resource.Address)] = id
+		graph.Nodes = append(graph.Nodes, ir.Node{ID: id, Address: resource.Address})
+	}
+
+	baseToChanges := make(map[string][]ir.NodeID)
+	for _, resource := range flattenConfigResources(configuration.RootModule) {
+		for addr, id := range changed {
+			if addr == resource.Address || strings.HasPrefix(addr, resource.Address+"[") {
+				baseToChanges[resource.Address] = append(baseToChanges[resource.Address], id)
+			}
+		}
+	}
+
+	edges := make(map[string]ir.Edge)
+	for _, resource := range flattenConfigResources(configuration.RootModule) {
+		targets := baseToChanges[resource.Address]
+		if len(targets) == 0 {
+			continue
+		}
+		for _, dependency := range resource.DependsOn {
+			for _, source := range resolveReference(dependency, changed, baseToChanges) {
+				for _, target := range targets {
+					addEdge(edges, source, target, ir.EdgeExplicitDependsOn, ir.ConfidenceExact)
+				}
+			}
+		}
+		for _, rawExpression := range resource.Expressions {
+			for _, reference := range extractReferences(rawExpression) {
+				for _, source := range resolveReference(reference, changed, baseToChanges) {
+					for _, target := range targets {
+						addEdge(edges, source, target, ir.EdgeExpressionRef, ir.ConfidenceExact)
+					}
+				}
+			}
+		}
+	}
+
+	for _, edge := range edges {
+		graph.Edges = append(graph.Edges, edge)
+	}
+	return graph
+}
+
+func addEdge(edges map[string]ir.Edge, from, to ir.NodeID, kind ir.EdgeKind, confidence ir.EvidenceConfidence) {
+	if from == "" || to == "" || from == to {
+		return
+	}
+	key := fmt.Sprintf("%s\x00%s\x00%s", from, to, kind)
+	edges[key] = ir.Edge{From: from, To: to, Kind: kind, Confidence: confidence}
+}
+
+func flattenConfigResources(root Module) []ConfigResource {
+	var out []ConfigResource
+	var visit func(Module)
+	visit = func(module Module) {
+		out = append(out, module.Resources...)
+		names := make([]string, 0, len(module.ModuleCalls))
+		for name := range module.ModuleCalls {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			call := module.ModuleCalls[name]
+			if call.Module != nil {
+				visit(*call.Module)
+			}
+		}
+	}
+	visit(root)
+	return out
+}
+
+func resolveReference(reference string, changed map[string]ir.NodeID, baseToChanges map[string][]ir.NodeID) []ir.NodeID {
+	if id, ok := changed[reference]; ok {
+		return []ir.NodeID{id}
+	}
+	if ids, ok := baseToChanges[reference]; ok {
+		return ids
+	}
+	return nil
+}
+
+func extractReferences(raw json.RawMessage) []string {
+	value, err := decodeJSON(raw)
+	if err != nil {
+		return nil
+	}
+	set := make(map[string]struct{})
+	walkReferences(value, set)
+	out := make([]string, 0, len(set))
+	for ref := range set {
+		out = append(out, ref)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func walkReferences(value any, refs map[string]struct{}) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			if key == "references" {
+				if values, ok := child.([]any); ok {
+					for _, value := range values {
+						if ref, ok := value.(string); ok {
+							refs[ref] = struct{}{}
+						}
+					}
+				}
+			}
+			walkReferences(child, refs)
+		}
+	case []any:
+		for _, child := range typed {
+			walkReferences(child, refs)
+		}
+	}
+}

--- a/internal/source/terraform/normalize_test.go
+++ b/internal/source/terraform/normalize_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terraform
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/yu/terraform-ops/internal/ir"
+)
+
+const canary = "TFOPS_CANARY_SECRET_92f84d"
+
+func TestNormalizeRedactsSensitiveValuesAndPreservesReplacementEvidence(t *testing.T) {
+	planJSON := `{
+  "format_version":"1.0",
+  "terraform_version":"1.15.8",
+  "applyable":true,
+  "complete":true,
+  "errored":false,
+  "variables":{"password":{"value":"` + canary + `"}},
+  "resource_changes":[{
+    "address":"test_resource.db",
+    "mode":"managed",
+    "type":"test_resource",
+    "name":"db",
+    "action_reason":"replace_because_cannot_update",
+    "change":{
+      "actions":["delete","create"],
+      "before":{"name":"db","password":"` + canary + `","disk":"old"},
+      "after":{"name":"db","password":"` + canary + `","disk":"new"},
+      "before_sensitive":{"password":true},
+      "after_sensitive":{"password":true},
+      "after_unknown":{"endpoint":true},
+      "replace_paths":[["disk"]]
+    }
+  }],
+  "resource_drift":[],
+  "output_changes":{},
+  "checks":[],
+  "configuration":{"root_module":{"resources":[],"module_calls":{},"outputs":{}}}
+}`
+	plan, err := ParseReader(strings.NewReader(planJSON), DefaultMaxPlanBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changeSet, err := Normalize(plan, ir.EngineTerraform, ir.RedactionStandard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changeSet.Plan.Applyable {
+		t.Fatal("applyable was not decoded")
+	}
+	if len(changeSet.Resources) != 1 {
+		t.Fatalf("got %d resources", len(changeSet.Resources))
+	}
+	resource := changeSet.Resources[0]
+	if !resource.Action.IsReplace() {
+		t.Fatalf("unexpected action: %s", resource.Action.Semantic)
+	}
+	if got := resource.ReplacePaths[0].String(); got != "disk" {
+		t.Fatalf("replace path = %q", got)
+	}
+	if got := resource.UnknownPaths[0].String(); got != "endpoint" {
+		t.Fatalf("unknown path = %q", got)
+	}
+	if got := resource.SensitivePaths[0].String(); got != "password" {
+		t.Fatalf("sensitive path = %q", got)
+	}
+	if changeSet.Redaction.VariableValuesRemoved != 1 {
+		t.Fatalf("variables removed = %d", changeSet.Redaction.VariableValuesRemoved)
+	}
+	data, err := json.Marshal(changeSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), canary) {
+		t.Fatal("sanitized change set leaked canary")
+	}
+}
+
+func TestNormalizeBuildsDependencyBlastRadius(t *testing.T) {
+	planJSON := `{
+  "format_version":"1.0",
+  "applyable":true,
+  "complete":true,
+  "errored":false,
+  "resource_changes":[
+    {"address":"test_resource.a","mode":"managed","type":"test_resource","name":"a","change":{"actions":["update"]}},
+    {"address":"test_resource.b","mode":"managed","type":"test_resource","name":"b","change":{"actions":["update"]}},
+    {"address":"test_resource.c","mode":"managed","type":"test_resource","name":"c","change":{"actions":["update"]}}
+  ],
+  "output_changes":{},
+  "configuration":{"root_module":{"resources":[
+    {"address":"test_resource.a","mode":"managed","type":"test_resource","name":"a","expressions":{}},
+    {"address":"test_resource.b","mode":"managed","type":"test_resource","name":"b","expressions":{"x":{"references":["test_resource.a","test_resource.a.id"]}}},
+    {"address":"test_resource.c","mode":"managed","type":"test_resource","name":"c","expressions":{"x":{"references":["test_resource.b"]}}}
+  ],"module_calls":{},"outputs":{}}}
+}`
+	plan, err := ParseReader(strings.NewReader(planJSON), DefaultMaxPlanBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changeSet, err := Normalize(plan, ir.EngineTerraform, ir.RedactionStandard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transitive := changeSet.Graph.TransitiveDependents(ir.NodeID("test_resource.a"))
+	if len(transitive) != 2 || transitive[0] != "test_resource.b" || transitive[1] != "test_resource.c" {
+		t.Fatalf("unexpected transitive dependents: %#v", transitive)
+	}
+}
+
+func TestParseRejectsUnsupportedMajorVersion(t *testing.T) {
+	_, err := ParseReader(strings.NewReader(`{"format_version":"2.0"}`), DefaultMaxPlanBytes)
+	if err == nil || !strings.Contains(err.Error(), "only major version 1") {
+		t.Fatalf("expected unsupported major version error, got %v", err)
+	}
+}

--- a/internal/source/terraform/normalize_test.go
+++ b/internal/source/terraform/normalize_test.go
@@ -124,9 +124,138 @@ func TestNormalizeBuildsDependencyBlastRadius(t *testing.T) {
 	}
 }
 
+func TestNormalizeTraversesModuleInputsAndOutputs(t *testing.T) {
+	planJSON := `{
+  "format_version":"1.0",
+  "terraform_version":"1.15.8",
+  "applyable":true,
+  "complete":true,
+  "errored":false,
+  "resource_changes":[
+    {"address":"test_resource.source","mode":"managed","type":"test_resource","name":"source","change":{"actions":["update"]}},
+    {"address":"module.child.test_resource.inner","module_address":"module.child","mode":"managed","type":"test_resource","name":"inner","change":{"actions":["update"]}},
+    {"address":"test_resource.consumer","mode":"managed","type":"test_resource","name":"consumer","change":{"actions":["update"]}}
+  ],
+  "output_changes":{},
+  "configuration":{"root_module":{
+    "resources":[
+      {"address":"test_resource.source","mode":"managed","type":"test_resource","name":"source","expressions":{}},
+      {"address":"test_resource.consumer","mode":"managed","type":"test_resource","name":"consumer","expressions":{"value":{"references":["module.child.result","module.child"]}}}
+    ],
+    "module_calls":{"child":{
+      "expressions":{"source_id":{"references":["test_resource.source.id","test_resource.source"]}},
+      "module":{
+        "resources":[
+          {"address":"test_resource.inner","mode":"managed","type":"test_resource","name":"inner","expressions":{"value":{"references":["var.source_id"]}}}
+        ],
+        "module_calls":{},
+        "outputs":{"result":{"expression":{"references":["test_resource.inner.id","test_resource.inner"]}}}
+      }
+    }},
+    "outputs":{}
+  }}
+}`
+	plan, err := ParseReader(strings.NewReader(planJSON), DefaultMaxPlanBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changeSet, err := Normalize(plan, ir.EngineTerraform, ir.RedactionStandard)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertGraphEdge(t, changeSet.Graph, "test_resource.source", "module.child.test_resource.inner", ir.EdgeModuleInput, ir.ConfidenceExact)
+	assertGraphEdge(t, changeSet.Graph, "module.child.test_resource.inner", "test_resource.consumer", ir.EdgeModuleOutput, ir.ConfidenceExact)
+
+	transitive := changeSet.Graph.TransitiveDependents(ir.NodeID("test_resource.source"))
+	if len(transitive) != 2 || transitive[0] != "module.child.test_resource.inner" || transitive[1] != "test_resource.consumer" {
+		t.Fatalf("unexpected module transitive dependents: %#v", transitive)
+	}
+}
+
+func TestNormalizeDefaultsMissingCompleteForTerraform17(t *testing.T) {
+	plan, err := ParseReader(strings.NewReader(`{
+  "format_version":"1.0",
+  "terraform_version":"1.7.5",
+  "applyable":true,
+  "errored":false,
+  "resource_changes":[],
+  "output_changes":{},
+  "configuration":{"root_module":{"resources":[],"module_calls":{},"outputs":{}}}
+}`), DefaultMaxPlanBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changeSet, err := Normalize(plan, ir.EngineTerraform, ir.RedactionStandard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changeSet.Plan.Complete {
+		t.Fatal("Terraform 1.7 plan without complete metadata must default to complete")
+	}
+}
+
+func TestNormalizePreservesExplicitIncomplete(t *testing.T) {
+	plan, err := ParseReader(strings.NewReader(`{
+  "format_version":"1.0",
+  "terraform_version":"1.7.5",
+  "applyable":true,
+  "complete":false,
+  "errored":false,
+  "resource_changes":[],
+  "output_changes":{},
+  "configuration":{"root_module":{"resources":[],"module_calls":{},"outputs":{}}}
+}`), DefaultMaxPlanBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changeSet, err := Normalize(plan, ir.EngineTerraform, ir.RedactionStandard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changeSet.Plan.Complete {
+		t.Fatal("explicit incomplete metadata must be preserved")
+	}
+}
+
+func TestNormalizeKeepsMissingCompleteConservativeForTerraform18(t *testing.T) {
+	plan, err := ParseReader(strings.NewReader(`{
+  "format_version":"1.0",
+  "terraform_version":"1.8.0",
+  "applyable":true,
+  "errored":false,
+  "resource_changes":[],
+  "output_changes":{},
+  "configuration":{"root_module":{"resources":[],"module_calls":{},"outputs":{}}}
+}`), DefaultMaxPlanBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changeSet, err := Normalize(plan, ir.EngineTerraform, ir.RedactionStandard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changeSet.Plan.Complete {
+		t.Fatal("missing complete metadata on Terraform 1.8+ must remain conservative")
+	}
+}
+
 func TestParseRejectsUnsupportedMajorVersion(t *testing.T) {
 	_, err := ParseReader(strings.NewReader(`{"format_version":"2.0"}`), DefaultMaxPlanBytes)
 	if err == nil || !strings.Contains(err.Error(), "only major version 1") {
 		t.Fatalf("expected unsupported major version error, got %v", err)
 	}
+}
+
+func assertGraphEdge(t *testing.T, graph ir.DependencyGraph, from, to string, kind ir.EdgeKind, confidence ir.EvidenceConfidence) {
+	t.Helper()
+	for _, edge := range graph.Edges {
+		if edge.From == ir.NodeID(from) && edge.To == ir.NodeID(to) && edge.Kind == kind {
+			if edge.Confidence != confidence {
+				t.Fatalf("edge %s -> %s (%s) confidence = %s, want %s", from, to, kind, edge.Confidence, confidence)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing edge %s -> %s (%s): %#v", from, to, kind, graph.Edges)
 }

--- a/internal/source/terraform/normalize_test.go
+++ b/internal/source/terraform/normalize_test.go
@@ -106,7 +106,7 @@ func TestNormalizeBuildsDependencyBlastRadius(t *testing.T) {
   "output_changes":{},
   "configuration":{"root_module":{"resources":[
     {"address":"test_resource.a","mode":"managed","type":"test_resource","name":"a","expressions":{}},
-    {"address":"test_resource.b","mode":"managed","type":"test_resource","name":"b","expressions":{"x":{"references":["test_resource.a","test_resource.a.id"]}}},
+    {"address":"test_resource.b","mode":"managed","type":"test_resource","name":"b","expressions":{"x":{"references":["test_resource.a.id"]}}},
     {"address":"test_resource.c","mode":"managed","type":"test_resource","name":"c","expressions":{"x":{"references":["test_resource.b"]}}}
   ],"module_calls":{},"outputs":{}}}
 }`

--- a/internal/source/terraform/plan.go
+++ b/internal/source/terraform/plan.go
@@ -110,7 +110,7 @@ type Configuration struct {
 type Module struct {
 	Resources   []ConfigResource        `json:"resources"`
 	Outputs     map[string]ConfigOutput `json:"outputs"`
-	ModuleCalls map[string]ModuleCall    `json:"module_calls"`
+	ModuleCalls map[string]ModuleCall   `json:"module_calls"`
 }
 
 type ConfigResource struct {

--- a/internal/source/terraform/plan.go
+++ b/internal/source/terraform/plan.go
@@ -32,7 +32,7 @@ type Plan struct {
 	FormatVersion      string                     `json:"format_version"`
 	TerraformVersion   string                     `json:"terraform_version"`
 	Applyable          bool                       `json:"applyable"`
-	Complete           bool                       `json:"complete"`
+	Complete           *bool                      `json:"complete"`
 	Errored            bool                       `json:"errored"`
 	ResourceChanges    []ResourceChange           `json:"resource_changes"`
 	ResourceDrift      []ResourceChange           `json:"resource_drift"`

--- a/internal/source/terraform/plan.go
+++ b/internal/source/terraform/plan.go
@@ -136,8 +136,15 @@ func ParseFile(path string, maxBytes int64) (*Plan, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open plan JSON: %w", err)
 	}
-	defer f.Close()
-	return ParseReader(f, maxBytes)
+	plan, parseErr := ParseReader(f, maxBytes)
+	closeErr := f.Close()
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("close plan JSON: %w", closeErr)
+	}
+	return plan, nil
 }
 
 func ParseReader(r io.Reader, maxBytes int64) (*Plan, error) {

--- a/internal/source/terraform/plan.go
+++ b/internal/source/terraform/plan.go
@@ -1,0 +1,193 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terraform
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+const DefaultMaxPlanBytes int64 = 64 << 20
+
+var ErrPlanTooLarge = errors.New("plan JSON exceeds maximum input size")
+
+type Plan struct {
+	FormatVersion      string                     `json:"format_version"`
+	TerraformVersion   string                     `json:"terraform_version"`
+	Applyable          bool                       `json:"applyable"`
+	Complete           bool                       `json:"complete"`
+	Errored            bool                       `json:"errored"`
+	ResourceChanges    []ResourceChange           `json:"resource_changes"`
+	ResourceDrift      []ResourceChange           `json:"resource_drift"`
+	RelevantAttributes []RelevantAttribute        `json:"relevant_attributes"`
+	OutputChanges      map[string]OutputChange    `json:"output_changes"`
+	Checks             []Check                    `json:"checks"`
+	Configuration      Configuration              `json:"configuration"`
+	Variables          map[string]json.RawMessage `json:"variables"`
+}
+
+type ResourceChange struct {
+	Address         string          `json:"address"`
+	PreviousAddress string          `json:"previous_address"`
+	ModuleAddress   string          `json:"module_address"`
+	Mode            string          `json:"mode"`
+	Type            string          `json:"type"`
+	Name            string          `json:"name"`
+	Index           json.RawMessage `json:"index"`
+	Deposed         string          `json:"deposed"`
+	Change          Change          `json:"change"`
+	ActionReason    string          `json:"action_reason"`
+}
+
+type Change struct {
+	Actions         []string          `json:"actions"`
+	Before          json.RawMessage   `json:"before"`
+	After           json.RawMessage   `json:"after"`
+	AfterUnknown    json.RawMessage   `json:"after_unknown"`
+	BeforeSensitive json.RawMessage   `json:"before_sensitive"`
+	AfterSensitive  json.RawMessage   `json:"after_sensitive"`
+	ReplacePaths    []json.RawMessage `json:"replace_paths"`
+	Importing       *Importing        `json:"importing"`
+}
+
+type Importing struct {
+	ID      string `json:"id"`
+	Unknown bool   `json:"unknown"`
+}
+
+type OutputChange struct {
+	Change Change `json:"change"`
+}
+
+type RelevantAttribute struct {
+	Resource  string          `json:"resource"`
+	Attribute json.RawMessage `json:"attribute"`
+}
+
+type Check struct {
+	Address   CheckAddress    `json:"address"`
+	Status    string          `json:"status"`
+	Instances []CheckInstance `json:"instances"`
+}
+
+type CheckAddress struct {
+	Kind      string `json:"kind"`
+	ToDisplay string `json:"to_display"`
+	Module    string `json:"module"`
+}
+
+type CheckInstance struct {
+	Address  CheckAddress   `json:"address"`
+	Status   string         `json:"status"`
+	Problems []CheckProblem `json:"problems"`
+}
+
+type CheckProblem struct {
+	Message string `json:"message"`
+}
+
+type Configuration struct {
+	RootModule Module `json:"root_module"`
+}
+
+type Module struct {
+	Resources   []ConfigResource        `json:"resources"`
+	Outputs     map[string]ConfigOutput `json:"outputs"`
+	ModuleCalls map[string]ModuleCall    `json:"module_calls"`
+}
+
+type ConfigResource struct {
+	Address     string                     `json:"address"`
+	Mode        string                     `json:"mode"`
+	Type        string                     `json:"type"`
+	Name        string                     `json:"name"`
+	Expressions map[string]json.RawMessage `json:"expressions"`
+	DependsOn   []string                   `json:"depends_on"`
+}
+
+type ConfigOutput struct {
+	Expression json.RawMessage `json:"expression"`
+}
+
+type ModuleCall struct {
+	Expressions map[string]json.RawMessage `json:"expressions"`
+	Module      *Module                    `json:"module"`
+}
+
+func ParseFile(path string, maxBytes int64) (*Plan, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open plan JSON: %w", err)
+	}
+	defer f.Close()
+	return ParseReader(f, maxBytes)
+}
+
+func ParseReader(r io.Reader, maxBytes int64) (*Plan, error) {
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxPlanBytes
+	}
+	limited := io.LimitReader(r, maxBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("read plan JSON: %w", err)
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("%w: limit is %d bytes", ErrPlanTooLarge, maxBytes)
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var plan Plan
+	if err := dec.Decode(&plan); err != nil {
+		return nil, fmt.Errorf("decode plan JSON: %w", err)
+	}
+	if err := validateFormatVersion(plan.FormatVersion); err != nil {
+		return nil, err
+	}
+	return &plan, nil
+}
+
+func validateFormatVersion(version string) error {
+	if version == "" {
+		return errors.New("plan JSON is missing format_version")
+	}
+	major, _, ok := strings.Cut(version, ".")
+	if !ok {
+		major = version
+	}
+	if major != "1" {
+		return fmt.Errorf("unsupported plan format version %q: only major version 1 is supported", version)
+	}
+	return nil
+}
+
+func decodeJSON(raw json.RawMessage) (any, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}

--- a/internal/terraform/summary/sanitization_test.go
+++ b/internal/terraform/summary/sanitization_test.go
@@ -16,6 +16,7 @@ package summary
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -61,11 +62,12 @@ func TestSummarizePlanRedactsNestedSensitiveKeyChanges(t *testing.T) {
 	if strings.Contains(string(data), canary) {
 		t.Fatal("legacy summary retained nested sensitive canary")
 	}
-	if !strings.Contains(string(data), "<redacted>") {
-		t.Fatal("expected redacted marker in detailed key changes")
-	}
 	if len(summary.Changes.Update) != 1 || !summary.Changes.Update[0].Sensitive {
 		t.Fatal("nested sensitivity was not detected")
+	}
+	keyChanges := fmt.Sprint(summary.Changes.Update[0].KeyChanges)
+	if !strings.Contains(keyChanges, "<redacted>") {
+		t.Fatalf("expected redacted marker in detailed key changes, got %s", keyChanges)
 	}
 }
 

--- a/internal/terraform/summary/sanitization_test.go
+++ b/internal/terraform/summary/sanitization_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package summary
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/yu/terraform-ops/internal/core"
+)
+
+func TestSummarizePlanRedactsNestedSensitiveKeyChanges(t *testing.T) {
+	const canary = "TFOPS_LEGACY_SUMMARY_CANARY_4d831a"
+	plan := &core.TerraformPlan{
+		FormatVersion: "1.0",
+		ResourceChanges: []core.ResourceChange{{
+			Address: "test_resource.example",
+			Mode:    "managed",
+			Type:    "test_resource",
+			Name:    "example",
+			Change: core.Change{
+				Actions: []string{"update"},
+				Before: map[string]interface{}{
+					"settings": map[string]interface{}{"password": canary, "name": "before"},
+				},
+				After: map[string]interface{}{
+					"settings": map[string]interface{}{"password": canary, "name": "after"},
+				},
+				BeforeSensitive: map[string]interface{}{
+					"settings": map[string]interface{}{"password": true},
+				},
+				AfterSensitive: map[string]interface{}{
+					"settings": map[string]interface{}{"password": true},
+				},
+			},
+		}},
+		OutputChanges: map[string]core.OutputChange{},
+	}
+
+	summary, err := NewSummarizer().SummarizePlan(plan, core.SummaryOptions{ShowDetails: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), canary) {
+		t.Fatal("legacy summary retained nested sensitive canary")
+	}
+	if !strings.Contains(string(data), "<redacted>") {
+		t.Fatal("expected redacted marker in detailed key changes")
+	}
+	if len(summary.Changes.Update) != 1 || !summary.Changes.Update[0].Sensitive {
+		t.Fatal("nested sensitivity was not detected")
+	}
+}
+
+func TestSummarizePlanTreatsBooleanSensitiveOutputMaskAsSensitive(t *testing.T) {
+	const canary = "TFOPS_OUTPUT_CANARY_f02a77"
+	plan := &core.TerraformPlan{
+		FormatVersion:   "1.0",
+		ResourceChanges: []core.ResourceChange{},
+		OutputChanges: map[string]core.OutputChange{
+			"secret": {
+				Change: core.Change{
+					Actions:        []string{"update"},
+					After:          canary,
+					AfterSensitive: true,
+				},
+			},
+	}
+
+	summary, err := NewSummarizer().SummarizePlan(plan, core.SummaryOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(summary.Outputs) != 1 || !summary.Outputs[0].Sensitive || summary.Outputs[0].Value != nil {
+		t.Fatalf("sensitive output was not suppressed: %#v", summary.Outputs)
+	}
+	data, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), canary) {
+		t.Fatal("sensitive output canary leaked")
+	}
+}

--- a/internal/terraform/summary/sanitization_test.go
+++ b/internal/terraform/summary/sanitization_test.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yu/terraform-ops/internal/core"
+	"github.com/yu-iskw/terraform-ops/internal/core"
 )
 
 func TestSummarizePlanRedactsNestedSensitiveKeyChanges(t *testing.T) {
@@ -82,6 +82,7 @@ func TestSummarizePlanTreatsBooleanSensitiveOutputMaskAsSensitive(t *testing.T) 
 					AfterSensitive: true,
 				},
 			},
+		},
 	}
 
 	summary, err := NewSummarizer().SummarizePlan(plan, core.SummaryOptions{})

--- a/internal/terraform/summary/sanitization_test.go
+++ b/internal/terraform/summary/sanitization_test.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yu-iskw/terraform-ops/internal/core"
+	"github.com/yu/terraform-ops/internal/core"
 )
 
 func TestSummarizePlanRedactsNestedSensitiveKeyChanges(t *testing.T) {

--- a/internal/terraform/summary/summarizer.go
+++ b/internal/terraform/summary/summarizer.go
@@ -97,7 +97,8 @@ func (s *Summarizer) groupResourceChanges(plan *core.TerraformPlan) core.Changes
 			Sensitive:     s.hasSensitiveValues(change.Change),
 		}
 
-		// Add key changes if details are requested
+		// Key changes are built only from recursively redacted values. This keeps the
+		// legacy summary command safe while it is incrementally migrated to the v2 IR.
 		summary.KeyChanges = s.extractKeyChanges(change)
 
 		// Group by primary action
@@ -130,7 +131,7 @@ func (s *Summarizer) summarizeOutputs(plan *core.TerraformPlan) []core.OutputSum
 			Sensitive: s.hasSensitiveValues(outputChange.Change),
 		}
 
-		// Add value if not sensitive
+		// Add value only if the source plan says no part of the output is sensitive.
 		if !summary.Sensitive {
 			summary.Value = outputChange.Change.After
 		}
@@ -174,41 +175,23 @@ func (s *Summarizer) extractProvider(address string) string {
 	return "unknown"
 }
 
-// hasSensitiveValues checks if a change has sensitive values
+// hasSensitiveValues checks recursively whether a Terraform/OpenTofu sensitivity
+// mask contains any true leaf. Source plan masks can be bools, nested objects, or
+// nested arrays; checking only top-level map values is insufficient.
 func (s *Summarizer) hasSensitiveValues(change core.Change) bool {
-	// Check after_sensitive
-	if change.AfterSensitive != nil {
-		if sensitiveMap, ok := change.AfterSensitive.(map[string]interface{}); ok {
-			for _, sensitive := range sensitiveMap {
-				if sensitiveBool, ok := sensitive.(bool); ok && sensitiveBool {
-					return true
-				}
-			}
-		}
-	}
-
-	// Check before_sensitive
-	if change.BeforeSensitive != nil {
-		if sensitiveMap, ok := change.BeforeSensitive.(map[string]interface{}); ok {
-			for _, sensitive := range sensitiveMap {
-				if sensitiveBool, ok := sensitive.(bool); ok && sensitiveBool {
-					return true
-				}
-			}
-		}
-	}
-
-	return false
+	return containsSensitive(change.AfterSensitive) || containsSensitive(change.BeforeSensitive)
 }
 
-// extractKeyChanges extracts key changes from a resource change
+// extractKeyChanges extracts key changes from recursively redacted resource values.
 func (s *Summarizer) extractKeyChanges(change core.ResourceChange) map[string]interface{} {
 	keyChanges := make(map[string]interface{})
+	before := redactSensitive(change.Change.Before, change.Change.BeforeSensitive)
+	after := redactSensitive(change.Change.After, change.Change.AfterSensitive)
 
 	// Extract key changes from before/after values
-	if change.Change.Before != nil && change.Change.After != nil {
-		if beforeMap, ok := change.Change.Before.(map[string]interface{}); ok {
-			if afterMap, ok := change.Change.After.(map[string]interface{}); ok {
+	if before != nil && after != nil {
+		if beforeMap, ok := before.(map[string]interface{}); ok {
+			if afterMap, ok := after.(map[string]interface{}); ok {
 				// Find changed keys
 				for key, afterValue := range afterMap {
 					if beforeValue, exists := beforeMap[key]; exists {
@@ -238,9 +221,9 @@ func (s *Summarizer) extractKeyChanges(change core.ResourceChange) map[string]in
 				}
 			}
 		}
-	} else if change.Change.Before == nil && change.Change.After != nil {
+	} else if before == nil && after != nil {
 		// Creating new resource
-		if afterMap, ok := change.Change.After.(map[string]interface{}); ok {
+		if afterMap, ok := after.(map[string]interface{}); ok {
 			for key, value := range afterMap {
 				keyChanges[key] = map[string]interface{}{
 					"from": nil,
@@ -248,9 +231,9 @@ func (s *Summarizer) extractKeyChanges(change core.ResourceChange) map[string]in
 				}
 			}
 		}
-	} else if change.Change.Before != nil && change.Change.After == nil {
+	} else if before != nil && after == nil {
 		// Deleting resource
-		if beforeMap, ok := change.Change.Before.(map[string]interface{}); ok {
+		if beforeMap, ok := before.(map[string]interface{}); ok {
 			for key, value := range beforeMap {
 				keyChanges[key] = map[string]interface{}{
 					"from": value,
@@ -276,6 +259,65 @@ func (s *Summarizer) getPrimaryAction(actions []string) string {
 
 	// Return the first action as primary
 	return actions[0]
+}
+
+func containsSensitive(mask interface{}) bool {
+	switch typed := mask.(type) {
+	case bool:
+		return typed
+	case map[string]interface{}:
+		for _, child := range typed {
+			if containsSensitive(child) {
+				return true
+			}
+		}
+	case []interface{}:
+		for _, child := range typed {
+			if containsSensitive(child) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// redactSensitive combines a decoded value with its sensitivity mask. A true
+// mask leaf replaces the corresponding value before any legacy summary DTO is
+// constructed, preventing KeyChanges from retaining raw secrets.
+func redactSensitive(value, mask interface{}) interface{} {
+	if sensitive, ok := mask.(bool); ok && sensitive {
+		return "<redacted>"
+	}
+	if mask == nil {
+		return value
+	}
+
+	switch typedValue := value.(type) {
+	case map[string]interface{}:
+		typedMask, _ := mask.(map[string]interface{})
+		out := make(map[string]interface{}, len(typedValue))
+		for key, child := range typedValue {
+			var childMask interface{}
+			if typedMask != nil {
+				childMask = typedMask[key]
+			}
+			out[key] = redactSensitive(child, childMask)
+		}
+		return out
+	case []interface{}:
+		typedMask, _ := mask.([]interface{})
+		out := make([]interface{}, len(typedValue))
+		for i, child := range typedValue {
+			var childMask interface{}
+			if i < len(typedMask) {
+				childMask = typedMask[i]
+			}
+			out[i] = redactSensitive(child, childMask)
+		}
+		return out
+	default:
+		return value
+	}
 }
 
 // contains checks if a slice contains a specific string

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,19 @@
+// Copyright 2026 yu-iskw
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+// Version is overridden at build time with -ldflags. Development builds that
+// do not provide build metadata intentionally retain the explicit fallback.
+var Version = "dev"

--- a/schemas/analysis-report-v1.schema.json
+++ b/schemas/analysis-report-v1.schema.json
@@ -3,7 +3,15 @@
   "$id": "https://github.com/yu-iskw/terraform-ops/schemas/analysis-report-v1.schema.json",
   "title": "terraform-ops analysis report v1",
   "type": "object",
-  "required": ["schema_version", "tool", "source", "plan", "summary", "graph", "redaction"],
+  "required": [
+    "schema_version",
+    "tool",
+    "source",
+    "plan",
+    "summary",
+    "graph",
+    "redaction"
+  ],
   "properties": {
     "schema_version": { "const": "1.0" },
     "tool": {
@@ -19,7 +27,9 @@
       "type": "object",
       "required": ["engine", "plan_format_version"],
       "properties": {
-        "engine": { "enum": ["terraform", "opentofu", "unknown-compatible"] },
+        "engine": {
+          "enum": ["terraform", "opentofu", "unknown-compatible"]
+        },
         "engine_version": { "type": "string" },
         "plan_format_version": { "type": "string" }
       },
@@ -51,7 +61,11 @@
     },
     "redaction": {
       "type": "object",
-      "required": ["mode", "terraform_sensitive_paths", "variable_values_removed"],
+      "required": [
+        "mode",
+        "terraform_sensitive_paths",
+        "variable_values_removed"
+      ],
       "properties": {
         "mode": { "enum": ["standard", "strict"] },
         "terraform_sensitive_paths": { "type": "integer", "minimum": 0 },

--- a/schemas/analysis-report-v1.schema.json
+++ b/schemas/analysis-report-v1.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/yu-iskw/terraform-ops/schemas/analysis-report-v1.schema.json",
+  "title": "terraform-ops analysis report v1",
+  "type": "object",
+  "required": ["schema_version", "tool", "source", "plan", "summary", "graph", "redaction"],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "tool": {
+      "type": "object",
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "const": "terraform-ops" },
+        "version": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "source": {
+      "type": "object",
+      "required": ["engine", "plan_format_version"],
+      "properties": {
+        "engine": { "enum": ["terraform", "opentofu", "unknown-compatible"] },
+        "engine_version": { "type": "string" },
+        "plan_format_version": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "plan": {
+      "type": "object",
+      "required": ["applyable", "complete", "errored"],
+      "properties": {
+        "applyable": { "type": "boolean" },
+        "complete": { "type": "boolean" },
+        "errored": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "summary": { "type": "object" },
+    "findings": { "type": "array" },
+    "changes": { "type": "array" },
+    "drift": { "type": "array" },
+    "checks": { "type": "array" },
+    "graph": {
+      "type": "object",
+      "required": ["nodes", "edges"],
+      "properties": {
+        "nodes": { "type": "integer", "minimum": 0 },
+        "edges": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    },
+    "redaction": {
+      "type": "object",
+      "required": ["mode", "terraform_sensitive_paths", "variable_values_removed"],
+      "properties": {
+        "mode": { "enum": ["standard", "strict"] },
+        "terraform_sensitive_paths": { "type": "integer", "minimum": 0 },
+        "variable_values_removed": { "type": "integer", "minimum": 0 },
+        "strict_values_removed": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary

Implements the first implementation-grade vertical slice of RFC-0001 (`terraform-ops v2 — Deterministic Terraform/OpenTofu Change Intelligence`).

This PR establishes the normalized analysis/security boundary and validates it end-to-end before migrating every legacy command or adding SARIF/GitHub/MCP surfaces.

### Added

- engine-neutral normalized `ChangeSet` IR
- bounded Terraform/OpenTofu-compatible JSON plan source adapter (64 MiB default input bound)
- plan-format 1.x major-version validation
- compatibility bridge for the current plan JSON `applyable` field while legacy `applicable` fixtures remain accepted during migration
- redaction-aware normalization using `before_sensitive` / `after_sensitive`
- strict redaction mode that removes all before/after resource values
- source variable values excluded from the normalized model
- replacement action order, `replace_paths`, `action_reason`, move/import metadata, unknown paths, drift, relevant attributes, and checks
- dependency graph from configuration `depends_on`, expression references, module inputs, and module outputs
- resource-address resolution for attribute traversals such as `aws_instance.web.id`
- direct/transitive blast-radius metrics
- deterministic analyzer registry with initial generic rules:
  - `TFOPS-PLAN-ERRORED`
  - `TFOPS-PLAN-INCOMPLETE`
  - `TFOPS-CHECK-FAILED`
  - `TFOPS-LIFECYCLE-DELETE`
  - `TFOPS-LIFECYCLE-REPLACE`
  - `TFOPS-DRIFT-DETECTED`
  - `TFOPS-SENSITIVE-MUTATION`
  - `TFOPS-UNKNOWN-AFTER`
- stable analysis report v1 + JSON Schema
- text / JSON / Markdown renderers
- new `terraform-ops analyze` command
- stdin support, `--engine`, `--redaction`, `--fail-on`, `--output`, and `--max-plan-bytes`
- build-time tool version metadata shared by the CLI and analysis reports
- docs for `analyze`

### Compatibility/security hardening

- hardened the legacy `summarize-plan` path while it awaits full IR migration:
  - recursively detects nested Terraform sensitivity masks
  - recursively redacts sensitive values before constructing `KeyChanges`
  - suppresses values for boolean-sensitive outputs
- added canary tests for both the v2 analyzer and legacy summary path
- extended the Terraform CI matrix through 1.15.8
- added a real-plan `analyze` integration workspace: every Terraform matrix lane generates a plan containing a known sensitive canary, proves the raw plan contains the canary, runs `terraform-ops analyze`, and verifies the report does not contain it while preserving sensitivity and dependency/blast-radius evidence
- updated Trivy from 0.63.0 to 0.70.0 because the old Trunk-managed binary URL returned 404; the final Trunk run successfully executes Trivy

### Review feedback addressed

- Terraform 1.7 compatibility: preserve presence of `complete`; when the field is omitted, pre-1.8 Terraform plans default to complete, explicit values are preserved, and 1.8+ missing metadata remains conservative
- module-boundary blast radius: preserve the existing resource-level graph and augment it with `module_calls.*.expressions`, child variable consumers, and child output producer traversal; emit `module_input` / `module_output` evidence, with heuristic conservative fallback when exact output attribution is unavailable
- report provenance: replace the hard-coded `dev` report version with `internal/version.Version`, inject it through Makefile `-ldflags`, pass the release tag explicitly in the release workflow, and expose the same version through the root CLI

## Security properties

Raw plan values are source-adapter data. They are sanitized before entering the normalized IR. Stable reports deliberately do not publish raw before/after values; they publish semantic/evidentiary data such as action order, replacement paths, reasons, checks, drift, unknown/sensitive paths, and graph metrics.

`--redaction strict` removes all before/after resource values from the normalized model, not only values marked sensitive by Terraform/OpenTofu.

No Terraform/OpenTofu command execution is introduced by the product command. No state mutation, apply/destroy, network access, dynamic plugin loading, or LLM dependency is introduced.

## Validation

Current PR head `99b83b4`:

- ✅ repository build + unit tests
- ✅ Trunk quality/security checks, including gofmt/goimports, golangci-lint, codespell, OSV, Trivy, TruffleHog, Prettier/Markdown/YAML checks
- ✅ Terraform integration lanes 1.7.0, 1.8.0, 1.9.0, 1.10.0, 1.11.0, 1.12.0, and 1.15.8
- ✅ real-plan sensitive-canary `analyze` integration test in every Terraform lane
- ✅ real child-module integration in every Terraform lane proves parent resource → module input → child resource → module output → parent consumer blast-radius propagation
- ✅ Terraform 1.7 generated-plan integration asserts omitted `complete` metadata is normalized as complete for a converged plan
- ✅ integration binary asserts report `tool.version` is populated and not `dev`

Manual adversarial review also found and fixed two issues that ordinary happy-path tests would have missed:

1. expression references such as `resource.name.id` initially undercounted blast radius because only exact resource addresses were resolved;
2. the pre-existing legacy `summarize-plan` implementation could retain nested sensitive values in detailed `KeyChanges` because its sensitivity detector only handled shallow masks.

## Scope intentionally deferred

The remaining RFC phases should stay in follow-up PRs after this foundation is reviewed:

- fully migrate `summarize-plan` onto the normalized IR
- migrate `plan-graph` onto the shared dependency graph
- retire the legacy raw plan DTO/parser after those command migrations
- add OpenTofu-generated compatibility lanes/fixtures (the adapter is designed for the compatible JSON contract, but this PR does not claim OpenTofu runtime validation)
- extend module dependency semantics for additional advanced/dynamic edge cases beyond the deterministic module input/output references covered here
- source-location mapping + SARIF
- `analyze-plan` GitHub Action
- Docker Compose compatibility harness
- read-only MCP server
- provider-aware intelligence packs

## Design notes

- `--engine auto` reports `unknown-compatible` rather than falsely claiming Terraform or OpenTofu when the compatible plan JSON itself does not reliably identify the producer.
- severity and confidence are separate concepts.
- blast radius is a metric/evidence source and is not automatically converted into security severity.
- resolved module input/output references are represented exactly; ambiguous module-output attribution falls back to conservative propagation with heuristic confidence rather than silently understating blast radius.
- the legacy summary hardening is a compatibility bridge, not a substitute for its planned migration to the v2 IR.
